### PR TITLE
Allow cleaning of orchestrator fixtures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^7.2",
         "symfony/framework-bundle": "^4.3",
-        "kununu/data-fixtures": "^6.0",
+        "kununu/data-fixtures": "^7.0",
         "symfony/config": "^4.3",
         "symfony/dependency-injection": "^4.3",
         "symfony/http-kernel": "^4.3"

--- a/src/Service/Orchestrator.php
+++ b/src/Service/Orchestrator.php
@@ -34,4 +34,9 @@ final class Orchestrator
     {
         $this->loader->registerInitializableFixture($className, ...$args);
     }
+
+    public function clearFixtures(): void
+    {
+        $this->loader->clearFixtures();
+    }
 }

--- a/src/Test/FixturesAwareTestCase.php
+++ b/src/Test/FixturesAwareTestCase.php
@@ -8,9 +8,13 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 
 abstract class FixturesAwareTestCase extends BaseWebTestCase
 {
+    private const KEY_CONNECTIONS = 'connections';
+    private const KEY_CACHE_POOLS = 'cache_pools';
+    private const KEY_ELASTICSEARCH = 'elastic_search';
+
     final protected function loadDbFixtures(string $connectionName, array $classNames = [], bool $append = false): void
     {
-        $this->getOrchestrator('connections', $connectionName)->execute($classNames, $append);
+        $this->getOrchestrator(self::KEY_CONNECTIONS, $connectionName)->execute($classNames, $append);
     }
 
     final protected function loadCachePoolFixtures(
@@ -18,7 +22,7 @@ abstract class FixturesAwareTestCase extends BaseWebTestCase
         array $classNames = [],
         bool $append = false
     ): void {
-        $this->getOrchestrator('cache_pools', $cachePoolServiceId)->execute($classNames, $append);
+        $this->getOrchestrator(self::KEY_CACHE_POOLS, $cachePoolServiceId)->execute($classNames, $append);
     }
 
     final protected function loadElasticSearchFixtures(
@@ -26,7 +30,7 @@ abstract class FixturesAwareTestCase extends BaseWebTestCase
         array $classNames = [],
         bool $append = false
     ): void {
-        $this->getOrchestrator('elastic_search', $alias)->execute($classNames, $append);
+        $this->getOrchestrator(self::KEY_ELASTICSEARCH, $alias)->execute($classNames, $append);
     }
 
     final protected function registerInitializableFixtureForDb(
@@ -34,7 +38,7 @@ abstract class FixturesAwareTestCase extends BaseWebTestCase
         string $className,
         ...$args
     ): void {
-        $this->getOrchestrator('connections', $connectionName)->registerInitializableFixture($className, ...$args);
+        $this->getOrchestrator(self::KEY_CONNECTIONS, $connectionName)->registerInitializableFixture($className, ...$args);
     }
 
     final protected function registerInitializableFixtureForCachePool(
@@ -42,7 +46,7 @@ abstract class FixturesAwareTestCase extends BaseWebTestCase
         string $className,
         ...$args
     ): void {
-        $this->getOrchestrator('cache_pools', $cachePoolServiceId)->registerInitializableFixture($className, ...$args);
+        $this->getOrchestrator(self::KEY_CACHE_POOLS, $cachePoolServiceId)->registerInitializableFixture($className, ...$args);
     }
 
     final protected function registerInitializableFixtureForElasticSearch(
@@ -50,7 +54,7 @@ abstract class FixturesAwareTestCase extends BaseWebTestCase
         string $className,
         ...$args
     ): void {
-        $this->getOrchestrator('elastic_search', $alias)->registerInitializableFixture($className, ...$args);
+        $this->getOrchestrator(self::KEY_ELASTICSEARCH, $alias)->registerInitializableFixture($className, ...$args);
     }
 
     final protected function getContainer(): ContainerInterface
@@ -60,6 +64,27 @@ abstract class FixturesAwareTestCase extends BaseWebTestCase
         }
 
         return static::$container;
+    }
+
+    final protected function clearDbFixtures(string $connectionName): self
+    {
+        $this->getOrchestrator(self::KEY_CONNECTIONS, $connectionName)->clearFixtures();
+
+        return $this;
+    }
+
+    final protected function clearCachePoolFixtures(string $cachePoolServiceId): self
+    {
+        $this->getOrchestrator(self::KEY_CACHE_POOLS, $cachePoolServiceId)->clearFixtures();
+
+        return $this;
+    }
+
+    final protected function clearElasticSearchFixtures(string $alias): self
+    {
+        $this->getOrchestrator(self::KEY_ELASTICSEARCH, $alias)->clearFixtures();
+
+        return $this;
     }
 
     private function getOrchestrator(string $type, string $key): Orchestrator

--- a/tests/App/Fixtures/Connection/ConnectionFixture5.php
+++ b/tests/App/Fixtures/Connection/ConnectionFixture5.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Kununu\TestingBundle\Tests\App\Fixtures\Connection;
+
+use Doctrine\DBAL\Connection;
+use Kununu\DataFixtures\Adapter\ConnectionFixtureInterface;
+
+final class ConnectionFixture5 implements ConnectionFixtureInterface
+{
+    public function load(Connection $connection): void
+    {
+        $connection->exec('INSERT INTO `table_3` (`name`, `description`) VALUES (\'my_name\', \'description5\');');
+    }
+}

--- a/tests/App/Fixtures/Connection/ConnectionFixture6.php
+++ b/tests/App/Fixtures/Connection/ConnectionFixture6.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Kununu\TestingBundle\Tests\App\Fixtures\Connection;
+
+use Doctrine\DBAL\Connection;
+use Kununu\DataFixtures\Adapter\ConnectionFixtureInterface;
+
+final class ConnectionFixture6 implements ConnectionFixtureInterface
+{
+    public function load(Connection $connection): void
+    {
+        $connection->exec('INSERT INTO `table_3` (`name`, `description`) VALUES (\'my_name\', \'description6\');');
+    }
+}

--- a/tests/Service/OrchestratorTest.php
+++ b/tests/Service/OrchestratorTest.php
@@ -32,6 +32,9 @@ final class OrchestratorTest extends TestCase
             ->expects($this->once())
             ->method('getFixtures')
             ->willReturn([$fixture1, $fixture2]);
+        $loader
+            ->expects($this->once())
+            ->method('clearFixtures');
 
         /** @var ExecutorInterface|MockObject $executor */
         $executor = $this->createMock(ExecutorInterface::class);
@@ -46,6 +49,7 @@ final class OrchestratorTest extends TestCase
         $orchestrator = new Orchestrator($executor, $purger, $loader);
 
         $orchestrator->execute(['Mock1', 'Mock2'], $append);
+        $orchestrator->clearFixtures();
     }
 
     public function executesAsExpectedDataProvider()


### PR DESCRIPTION
- Bump kununu/data-fixtures to v7.0

- Add method on Orchestrator to clear loaded fixtures

- Add methods on FixturesAwareTestCase to clear loaded fixtures for Database, Cache Pool and Elasticsearch

- Add integration tests to cover new methods