### PR TITLE
Drop support for PHP 7.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
     labels:
       - "dependencies"
     versioning-strategy: auto
-    # By default Dependabot has a limit of the number of open PR for version updates
-    # and security updates. 
+    # By default, Dependabot has a limit of the number of open PR for version updates
+    # and security updates.
     # See other defaults in here: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,9 +17,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.2
-          - 7.3
-          - 7.4
           - 8.0
         mysql-version:
           - 5.7
@@ -107,7 +104,7 @@ jobs:
 
       - uses: actions/download-artifact@v2
         with:
-          name: build-7.4-coverage
+          name: build-8-coverage
           path: tests/.results/
 
       - name: Fix Code Coverage Paths

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": ">=8.0",
         "symfony/framework-bundle": "^4.4 || ^5.0",
-        "kununu/data-fixtures": "^9.1",
+        "kununu/data-fixtures": "^10.0",
         "symfony/config": "^4.4 || ^5.0",
         "symfony/dependency-injection": "^4.4 || ^5.0",
         "symfony/http-kernel": "^4.4 || ^5.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,36 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-        bootstrap="tests/bootstrap.php"
-        colors="true"
-        beStrictAboutChangesToGlobalState="true">
+<!-- https://phpunit.readthedocs.io/en/9.6/ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd" bootstrap="tests/bootstrap.php"
+         colors="true" beStrictAboutChangesToGlobalState="true">
+    <coverage processUncoveredFiles="false">
+        <include>
+            <directory>src</directory>
+        </include>
+        <exclude>
+            <file>src/Traits/ConnectionToolsTrait.php</file>
+        </exclude>
+        <report>
+            <clover outputFile="tests/.results/tests-clover.xml"/>
+            <html outputDirectory="tests/.results/html/"/>
+        </report>
+    </coverage>
     <php>
         <ini name="error_reporting" value="-1"/>
         <server name="APP_ENV" value="test" force="true"/>
     </php>
     <testsuites>
         <testsuite name="TestingBundle Test Suite">
-            <directory>./tests/</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="false">
-            <directory>src</directory>
-            <exclude>
-                <file>src/Traits/ConnectionToolsTrait.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
-
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     </listeners>
-
     <logging>
-        <log type="coverage-clover" target="tests/.results/tests-clover.xml"/>
-        <log type="junit" target="tests/.results/tests-junit.xml"/>
-        <log type="coverage-html" target="tests/.results/html/"/>
+        <junit outputFile="tests/.results/tests-junit.xml"/>
     </logging>
 </phpunit>

--- a/src/DependencyInjection/Compiler/AbstractCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AbstractCompilerPass.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\TestingBundle\DependencyInjection\Compiler;
+
+use Kununu\TestingBundle\DependencyInjection\ExtensionConfigurationInterface;
+use Kununu\TestingBundle\DependencyInjection\KununuTestingExtension;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+abstract class AbstractCompilerPass implements CompilerPassInterface
+{
+    protected function getExtensionConfiguration(ContainerBuilder $containerBuilder): ?array
+    {
+        if (!$containerBuilder->hasExtension(KununuTestingExtension::ALIAS)) {
+            return null;
+        }
+
+        $extension = $containerBuilder->getExtension(KununuTestingExtension::ALIAS);
+
+        return $extension instanceof ExtensionConfigurationInterface
+            ? $extension->getConfig()
+            : null;
+    }
+}

--- a/src/DependencyInjection/Compiler/HttpClientCompilerPass.php
+++ b/src/DependencyInjection/Compiler/HttpClientCompilerPass.php
@@ -6,19 +6,16 @@ namespace Kununu\TestingBundle\DependencyInjection\Compiler;
 use Kununu\DataFixtures\Executor\HttpClientExecutor;
 use Kununu\DataFixtures\Loader\HttpClientFixturesLoader;
 use Kununu\DataFixtures\Purger\HttpClientPurger;
-use Kununu\TestingBundle\DependencyInjection\ExtensionConfiguration;
-use Kununu\TestingBundle\DependencyInjection\KununuTestingExtension;
 use Kununu\TestingBundle\Service\Orchestrator;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
-final class HttpClientCompilerPass implements CompilerPassInterface
+final class HttpClientCompilerPass extends AbstractCompilerPass
 {
     private const SERVICE_PREFIX = 'kununu_testing.orchestrator.http_client';
 
-    private $config;
+    private array $config = [];
 
     public function process(ContainerBuilder $container): void
     {
@@ -33,47 +30,49 @@ final class HttpClientCompilerPass implements CompilerPassInterface
 
     private function canBuildOrchestrators(ContainerBuilder $containerBuilder): bool
     {
-        if (!$containerBuilder->hasExtension(KununuTestingExtension::ALIAS) ||
-            !($extension = $containerBuilder->getExtension(KununuTestingExtension::ALIAS)) instanceof ExtensionConfiguration
-        ) {
+        if (null === ($configuration = $this->getExtensionConfiguration($containerBuilder))) {
             return false;
         }
 
-        $this->config = $extension->getConfig()['http_client'] ?? [];
+        $this->config = $configuration['http_client'] ?? [];
 
         return count($this->config['clients'] ?? []) > 0;
     }
 
     private function buildHttpClientOrchestrator(ContainerBuilder $container, string $id): void
     {
-        $httpClient = new Reference($id);
-
-        // Purger Definition
+        // Purger Definition for HttpClient with provided $id
         $purgerId = sprintf('%s.%s.purger', self::SERVICE_PREFIX, $id);
-        $purgerDefinition = new Definition(HttpClientPurger::class, [$httpClient]);
+        $purgerDefinition = new Definition(
+            HttpClientPurger::class,
+            [
+                $httpClient = new Reference($id),
+            ]
+        );
         $container->setDefinition($purgerId, $purgerDefinition);
 
-        // Executor Definition
+        // Executor Definition for HttpClient with provided $id
         $executorId = sprintf('%s.%s.executor', self::SERVICE_PREFIX, $id);
         $executorDefinition = new Definition(HttpClientExecutor::class, [$httpClient, new Reference($purgerId)]);
         $container->setDefinition($executorId, $executorDefinition);
 
-        // Loader definition
+        // Loader definition for HttpClient with provided $id
         $loaderId = sprintf('%s.%s.loader', self::SERVICE_PREFIX, $id);
         $loaderDefinition = new Definition(HttpClientFixturesLoader::class);
         $container->setDefinition($loaderId, $loaderDefinition);
 
-        $connectionOrchestratorDefinition = new Definition(
+        // Orchestrator definition for HttpClient with provided $id
+        $orchestratorDefinition = new Definition(
             Orchestrator::class,
             [
                 new Reference($executorId),
                 new Reference($loaderId),
             ]
         );
-        $connectionOrchestratorDefinition->setPublic(true);
+        $orchestratorDefinition->setPublic(true);
 
         $orchestratorId = sprintf('%s.%s', self::SERVICE_PREFIX, $id);
 
-        $container->setDefinition($orchestratorId, $connectionOrchestratorDefinition);
+        $container->setDefinition($orchestratorId, $orchestratorDefinition);
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -12,10 +12,9 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('kununu_testing');
-        $rootNode = $treeBuilder->getRootNode()->fixXmlConfig('connection');
 
         $this
-            ->addConnectionsSection($rootNode, 'connections')
+            ->addConnectionsSection($rootNode = $treeBuilder->getRootNode()->fixXmlConfig('connection'), 'connections')
             ->addConnectionsSection($rootNode, 'non_transactional_connections')
             ->addElasticSearchSection($rootNode)
             ->addCacheSection($rootNode)

--- a/src/DependencyInjection/ExtensionConfigurationInterface.php
+++ b/src/DependencyInjection/ExtensionConfigurationInterface.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Kununu\TestingBundle\DependencyInjection;
 
-interface ExtensionConfiguration
+interface ExtensionConfigurationInterface
 {
     public function getConfig(): array;
 }

--- a/src/DependencyInjection/KununuTestingExtension.php
+++ b/src/DependencyInjection/KununuTestingExtension.php
@@ -8,11 +8,11 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
-final class KununuTestingExtension extends Extension implements ExtensionConfiguration
+final class KununuTestingExtension extends Extension implements ExtensionConfigurationInterface
 {
     public const ALIAS = 'kununu_testing';
 
-    private $config = [];
+    private array $config = [];
 
     public function load(array $configs, ContainerBuilder $container): void
     {

--- a/src/KununuTestingBundle.php
+++ b/src/KununuTestingBundle.php
@@ -16,8 +16,6 @@ final class KununuTestingBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {
-        parent::build($container);
-
         $container->addCompilerPass(new CachePoolCompilerPass());
         $container->addCompilerPass(new ConnectionCompilerPass());
         $container->addCompilerPass(new NonTransactionalConnectionCompilerPass());

--- a/src/Service/Orchestrator.php
+++ b/src/Service/Orchestrator.php
@@ -6,15 +6,10 @@ namespace Kununu\TestingBundle\Service;
 use Kununu\DataFixtures\Executor\ExecutorInterface;
 use Kununu\DataFixtures\Loader\LoaderInterface;
 
-final class Orchestrator
+final class Orchestrator implements OrchestratorInterface
 {
-    private $executor;
-    private $loader;
-
-    public function __construct(ExecutorInterface $executor, LoaderInterface $loader)
+    public function __construct(private ExecutorInterface $executor, private LoaderInterface $loader)
     {
-        $this->executor = $executor;
-        $this->loader = $loader;
     }
 
     public function execute(array $fixturesClassNames, bool $append, bool $clearFixtures = true): void
@@ -30,7 +25,7 @@ final class Orchestrator
         $this->executor->execute($this->loader->getFixtures(), $append);
     }
 
-    public function registerInitializableFixture(string $className, ...$args): void
+    public function registerInitializableFixture(string $className, mixed ...$args): void
     {
         $this->loader->registerInitializableFixture($className, ...$args);
     }

--- a/src/Service/OrchestratorInterface.php
+++ b/src/Service/OrchestratorInterface.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\TestingBundle\Service;
+
+interface OrchestratorInterface
+{
+    public function execute(array $fixturesClassNames, bool $append, bool $clearFixtures = true): void;
+
+    public function registerInitializableFixture(string $className, mixed ...$args): void;
+
+    public function clearFixtures(): void;
+
+    public function getFixtures(): array;
+}

--- a/src/Service/SchemaCopy/Adapter/AbstractAdapter.php
+++ b/src/Service/SchemaCopy/Adapter/AbstractAdapter.php
@@ -13,11 +13,8 @@ abstract class AbstractAdapter implements SchemaCopyAdapterInterface
 
     protected const TYPE = '';
 
-    protected $connection;
-
-    public function __construct(Connection $connection)
+    public function __construct(protected Connection $connection)
     {
-        $this->connection = $connection;
     }
 
     public function runCopy(callable $fn): void

--- a/src/Service/SchemaCopy/Copier/SchemaCopier.php
+++ b/src/Service/SchemaCopy/Copier/SchemaCopier.php
@@ -13,11 +13,8 @@ final class SchemaCopier implements SchemaCopyInterface
 {
     use ConnectionToolsTrait;
 
-    private $adapterFactory;
-
-    public function __construct(SchemaCopyAdapterFactoryInterface $adapterFactory)
+    public function __construct(private SchemaCopyAdapterFactoryInterface $adapterFactory)
     {
-        $this->adapterFactory = $adapterFactory;
     }
 
     public function copy(Connection $source, Connection $destination): void

--- a/src/Test/FixturesAwareTestCase.php
+++ b/src/Test/FixturesAwareTestCase.php
@@ -17,44 +17,63 @@ abstract class FixturesAwareTestCase extends BaseWebTestCase
     private const KEY_ELASTICSEARCH = 'elastic_search';
     private const KEY_HTTP_CLIENT = 'http_client';
 
-    final protected function loadDbFixtures(string $connectionName, DbOptionsInterface $options, string ...$classNames): void
-    {
+    final protected function loadDbFixtures(
+        string $connectionName,
+        DbOptionsInterface $options,
+        string ...$classNames
+    ): void {
         $this
-            ->getOrchestrator($options->transactional() ? self::KEY_CONNECTIONS : self::KEY_NON_TRANSACTIONAL_CONNECTIONS, $connectionName)
+            ->getOrchestrator(
+                $options->transactional() ? self::KEY_CONNECTIONS : self::KEY_NON_TRANSACTIONAL_CONNECTIONS,
+                $connectionName
+            )
             ->execute($classNames, $options->append(), $options->clear());
     }
 
-    final protected function loadCachePoolFixtures(string $cachePoolServiceId, OptionsInterface $options, string ...$classNames): void
-    {
+    final protected function loadCachePoolFixtures(
+        string $cachePoolServiceId,
+        OptionsInterface $options,
+        string ...$classNames
+    ): void {
         $this
             ->getOrchestrator(self::KEY_CACHE_POOLS, $cachePoolServiceId)
             ->execute($classNames, $options->append(), $options->clear());
     }
 
-    final protected function loadElasticSearchFixtures(string $alias, OptionsInterface $options, string ...$classNames): void
-    {
-        $this->getOrchestrator(self::KEY_ELASTICSEARCH, $alias)
+    final protected function loadElasticSearchFixtures(
+        string $alias,
+        OptionsInterface $options,
+        string ...$classNames
+    ): void {
+        $this
+            ->getOrchestrator(self::KEY_ELASTICSEARCH, $alias)
             ->execute($classNames, $options->append(), $options->clear());
     }
 
-    final protected function loadHttpClientFixtures(string $httpClientServiceId, OptionsInterface $options, string ...$classNames): void
-    {
-        $this->getOrchestrator(self::KEY_HTTP_CLIENT, $httpClientServiceId)
+    final protected function loadHttpClientFixtures(
+        string $httpClientServiceId,
+        OptionsInterface $options,
+        string ...$classNames
+    ): void {
+        $this
+            ->getOrchestrator(self::KEY_HTTP_CLIENT, $httpClientServiceId)
             ->execute($classNames, $options->append(), $options->clear());
     }
 
     final protected function registerInitializableFixtureForDb(
         string $connectionName,
         string $className,
-        ...$args
+        mixed ...$args
     ): void {
-        $this->getOrchestrator(self::KEY_CONNECTIONS, $connectionName)->registerInitializableFixture($className, ...$args);
+        $this
+            ->getOrchestrator(self::KEY_CONNECTIONS, $connectionName)
+            ->registerInitializableFixture($className, ...$args);
     }
 
     final protected function registerInitializableFixtureForNonTransactionalDb(
         string $connectionName,
         string $className,
-        ...$args
+        mixed ...$args
     ): void {
         $this
             ->getOrchestrator(self::KEY_NON_TRANSACTIONAL_CONNECTIONS, $connectionName)
@@ -64,30 +83,39 @@ abstract class FixturesAwareTestCase extends BaseWebTestCase
     final protected function registerInitializableFixtureForCachePool(
         string $cachePoolServiceId,
         string $className,
-        ...$args
+        mixed ...$args
     ): void {
-        $this->getOrchestrator(self::KEY_CACHE_POOLS, $cachePoolServiceId)->registerInitializableFixture($className, ...$args);
+        $this
+            ->getOrchestrator(self::KEY_CACHE_POOLS, $cachePoolServiceId)
+            ->registerInitializableFixture($className, ...$args);
     }
 
     final protected function registerInitializableFixtureForElasticSearch(
         string $alias,
         string $className,
-        ...$args
+        mixed ...$args
     ): void {
-        $this->getOrchestrator(self::KEY_ELASTICSEARCH, $alias)->registerInitializableFixture($className, ...$args);
+        $this
+            ->getOrchestrator(self::KEY_ELASTICSEARCH, $alias)
+            ->registerInitializableFixture($className, ...$args);
     }
 
     final protected function registerInitializableFixtureForHttpClient(
         string $httpClientServiceId,
         string $className,
-        ...$args
+        mixed ...$args
     ): void {
-        $this->getOrchestrator(self::KEY_HTTP_CLIENT, $httpClientServiceId)->registerInitializableFixture($className, ...$args);
+        $this
+            ->getOrchestrator(self::KEY_HTTP_CLIENT, $httpClientServiceId)
+            ->registerInitializableFixture($className, ...$args);
     }
 
     final protected function getFixturesContainer(): ContainerInterface
     {
-        if (!static::$kernel || !(method_exists(static::class, 'getContainer') ? static::getContainer() : static::$container)) {
+        if (
+            !static::$kernel ||
+            !(method_exists(static::class, 'getContainer') ? static::getContainer() : static::$container)
+        ) {
             static::createClient();
         }
 
@@ -97,7 +125,10 @@ abstract class FixturesAwareTestCase extends BaseWebTestCase
     final protected function clearDbFixtures(string $connectionName, DbOptionsInterface $options): self
     {
         $this
-            ->getOrchestrator($options->transactional() ? self::KEY_CONNECTIONS : self::KEY_NON_TRANSACTIONAL_CONNECTIONS, $connectionName)
+            ->getOrchestrator(
+                $options->transactional() ? self::KEY_CONNECTIONS : self::KEY_NON_TRANSACTIONAL_CONNECTIONS,
+                $connectionName
+            )
             ->clearFixtures();
 
         return $this;
@@ -106,7 +137,10 @@ abstract class FixturesAwareTestCase extends BaseWebTestCase
     final protected function getDbFixtures(string $connectionName, DbOptionsInterface $options): array
     {
         return $this
-            ->getOrchestrator($options->transactional() ? self::KEY_CONNECTIONS : self::KEY_NON_TRANSACTIONAL_CONNECTIONS, $connectionName)
+            ->getOrchestrator(
+                $options->transactional() ? self::KEY_CONNECTIONS : self::KEY_NON_TRANSACTIONAL_CONNECTIONS,
+                $connectionName
+            )
             ->getFixtures();
     }
 

--- a/src/Test/Options/AbstractOptions.php
+++ b/src/Test/Options/AbstractOptions.php
@@ -10,7 +10,7 @@ abstract class AbstractOptions
     private const PREFIX_WITH = 'with';
     private const PREFIX_WITHOUT = 'without';
 
-    private $options = [];
+    private array $options = [];
 
     protected function __construct()
     {
@@ -24,14 +24,12 @@ abstract class AbstractOptions
         }
     }
 
-    /** @return static */
-    public static function create(): self
+    public static function create(): static
     {
         return new static();
     }
 
-    /** @return static */
-    public function __call(string $method, array $args)
+    public function __call(string $method, array $args): static
     {
         foreach ([self::PREFIX_WITHOUT => false, self::PREFIX_WITH => true] as $prefix => $value) {
             if ($prefix === substr($method, 0, $setterPrefixLen = strlen($prefix))) {

--- a/src/Test/RequestBuilder.php
+++ b/src/Test/RequestBuilder.php
@@ -7,21 +7,14 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class RequestBuilder
 {
-    private $method;
+    private ?string $uri = null;
+    private array $parameters = [];
+    private array $files = [];
+    private array $server = [];
+    private ?string $content = null;
 
-    private $uri;
-
-    private $parameters = [];
-
-    private $files = [];
-
-    private $server = [];
-
-    private $content;
-
-    private function __construct(string $method)
+    private function __construct(private string $method)
     {
-        $this->method = $method;
     }
 
     public static function aGetRequest(): self
@@ -96,7 +89,7 @@ final class RequestBuilder
     {
         $headerName = strtoupper($headerName);
 
-        if (substr($headerName, 0, 5) !== 'HTTP_') {
+        if (!str_starts_with($headerName, 'HTTP_')) {
             $headerName = sprintf('HTTP_%s', $headerName);
         }
 

--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -8,8 +8,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 abstract class WebTestCase extends FixturesAwareTestCase
 {
-    /** @var KernelBrowser */
-    private $client;
+    private ?KernelBrowser $client = null;
 
     final protected function doRequest(RequestBuilder $builder, bool $shutdown = true): Response
     {

--- a/tests/App/Command/CreateElasticsearchIndexCommand.php
+++ b/tests/App/Command/CreateElasticsearchIndexCommand.php
@@ -13,12 +13,8 @@ final class CreateElasticsearchIndexCommand extends Command
 {
     protected static $defaultName = 'app:elasticsearch:create-index';
 
-    private $elasticsearchClient;
-
-    public function __construct(Client $elasticsearchClient)
+    public function __construct(private Client $elasticsearchClient)
     {
-        $this->elasticsearchClient = $elasticsearchClient;
-
         parent::__construct();
     }
 

--- a/tests/App/Fixtures/CachePool/CachePoolFixture1.php
+++ b/tests/App/Fixtures/CachePool/CachePoolFixture1.php
@@ -9,7 +9,7 @@ use Psr\Cache\CacheItemPoolInterface;
 
 final class CachePoolFixture1 implements CachePoolFixtureInterface, InitializableFixtureInterface
 {
-    private $arg1;
+    private mixed $arg1;
 
     public function load(CacheItemPoolInterface $cachePool): void
     {
@@ -22,14 +22,14 @@ final class CachePoolFixture1 implements CachePoolFixtureInterface, Initializabl
         $cachePool->save($item1);
     }
 
-    public function initializeFixture(...$args): void
+    public function initializeFixture(mixed ...$args): void
     {
         if (count($args)) {
             $this->arg1 = $args[0];
         }
     }
 
-    public function arg1()
+    public function arg1(): mixed
     {
         return $this->arg1;
     }

--- a/tests/App/Fixtures/Connection/ConnectionFixture1.php
+++ b/tests/App/Fixtures/Connection/ConnectionFixture1.php
@@ -12,8 +12,8 @@ final class ConnectionFixture1 implements ConnectionFixtureInterface, Initializa
 {
     use ConnectionToolsTrait;
 
-    private $arg1;
-    private $arg2 = false;
+    private ?string $arg1 = null;
+    private bool $arg2 = false;
 
     public function load(Connection $connection): void
     {
@@ -21,7 +21,7 @@ final class ConnectionFixture1 implements ConnectionFixtureInterface, Initializa
         $this->executeQuery($connection, 'INSERT INTO `table_2` (`name`, `description`) VALUES (\'name\', \'description\');');
     }
 
-    public function initializeFixture(...$args): void
+    public function initializeFixture(mixed ...$args): void
     {
         foreach ($args as $index => $arg) {
             if (0 === $index && is_string($arg)) {

--- a/tests/App/Fixtures/ElasticSearch/ElasticSearchFixture1.php
+++ b/tests/App/Fixtures/ElasticSearch/ElasticSearchFixture1.php
@@ -9,8 +9,8 @@ use Kununu\DataFixtures\InitializableFixtureInterface;
 
 final class ElasticSearchFixture1 implements ElasticSearchFixtureInterface, InitializableFixtureInterface
 {
-    private $arg1;
-    private $arg2;
+    private ?int $arg1 = null;
+    private ?array $arg2 = null;
 
     public function load(Client $elasticSearch, string $indexName): void
     {
@@ -23,7 +23,7 @@ final class ElasticSearchFixture1 implements ElasticSearchFixtureInterface, Init
         );
     }
 
-    public function initializeFixture(...$args): void
+    public function initializeFixture(mixed ...$args): void
     {
         foreach ($args as $index => $arg) {
             if (0 === $index && is_int($arg)) {

--- a/tests/App/Fixtures/HttpClient/HttpClientFixture1.php
+++ b/tests/App/Fixtures/HttpClient/HttpClientFixture1.php
@@ -15,7 +15,7 @@ final class HttpClientFixture1 extends HttpClientPhpArrayFixture implements Init
         ];
     }
 
-    public function initializeFixture(...$args): void
+    public function initializeFixture(mixed ...$args): void
     {
     }
 }

--- a/tests/App/config/services.yaml
+++ b/tests/App/config/services.yaml
@@ -1,20 +1,20 @@
 services:
-    _defaults:
-        autowire: true
-        autoconfigure: true
+  _defaults:
+    autowire: true
+    autoconfigure: true
 
-    Kununu\TestingBundle\Tests\App\Command\:
-        resource: '../Command/*'
+  Kununu\TestingBundle\Tests\App\Command\:
+    resource: '../Command/*'
 
-    Kununu\TestingBundle\Tests\App\ElasticSearch\ClientFactory:
+  Kununu\TestingBundle\Tests\App\ElasticSearch\ClientFactory:
 
-    Kununu\TestingBundle\Tests\App\ElasticSearch:
-        factory: ['@Kununu\TestingBundle\Tests\App\ElasticSearch\ClientFactory', getInstance]
-        arguments:
-            - ['%elasticsearch_url%']
+  Kununu\TestingBundle\Tests\App\ElasticSearch:
+    factory: [ '@Kununu\TestingBundle\Tests\App\ElasticSearch\ClientFactory', getInstance ]
+    arguments:
+      - [ '%elasticsearch_url%' ]
 
-    Elasticsearch\Client: '@Kununu\TestingBundle\Tests\App\ElasticSearch'
+  Elasticsearch\Client: '@Kununu\TestingBundle\Tests\App\ElasticSearch'
 
-    http_client:
-        class: Kununu\DataFixtures\Tools\HttpClient
-        public: true
+  http_client:
+    class: Kununu\DataFixtures\Tools\HttpClient
+    public: true

--- a/tests/App/config/services_test.yaml
+++ b/tests/App/config/services_test.yaml
@@ -1,4 +1,4 @@
 services:
-    '@Kununu\TestingBundle\Tests\App\ElasticSearch':
-        public: true
-        synthetic: true
+  '@Kununu\TestingBundle\Tests\App\ElasticSearch':
+    public: true
+    synthetic: true

--- a/tests/Command/AbstractCommandTestCase.php
+++ b/tests/Command/AbstractCommandTestCase.php
@@ -10,10 +10,8 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 abstract class AbstractCommandTestCase extends FixturesAwareTestCase
 {
-    /** @var Application */
-    protected $application;
-    /** @var CommandTester */
-    protected $commandTester;
+    protected Application $application;
+    protected CommandTester $commandTester;
 
     public function testExistsCommands(): void
     {

--- a/tests/Command/AbstractLoadConnectionTestCase.php
+++ b/tests/Command/AbstractLoadConnectionTestCase.php
@@ -10,8 +10,7 @@ abstract class AbstractLoadConnectionTestCase extends AbstractFixturesCommandTes
 {
     use ConnectionToolsTrait;
 
-    /** @var Connection */
-    private $connection;
+    private Connection $connection;
 
     public function testExecuteInteractiveCancelled(): void
     {

--- a/tests/Command/CopyConnectionSchemaCommandTest.php
+++ b/tests/Command/CopyConnectionSchemaCommandTest.php
@@ -6,10 +6,9 @@ namespace Kununu\TestingBundle\Tests\Command;
 use Doctrine\DBAL\Connection;
 use Kununu\TestingBundle\Command\CopyConnectionSchemaCommand;
 use Kununu\TestingBundle\Service\SchemaCopy\SchemaCopyAdapterFactoryInterface;
+use Kununu\TestingBundle\Service\SchemaCopy\SchemaCopyAdapterInterface;
 
-/**
- * @group legacy
- */
+/** @group legacy */
 final class CopyConnectionSchemaCommandTest extends AbstractCommandTestCase
 {
     private const COMMAND = 'kununu_testing:connections:schema:copy';
@@ -26,7 +25,7 @@ final class CopyConnectionSchemaCommandTest extends AbstractCommandTestCase
         'my_view',
     ];
 
-    private $adapter;
+    private SchemaCopyAdapterInterface $adapter;
 
     public function testCommandValidNonInteractive(): void
     {

--- a/tests/Command/LoadCacheFixturesCommandTest.php
+++ b/tests/Command/LoadCacheFixturesCommandTest.php
@@ -8,16 +8,13 @@ use Kununu\TestingBundle\Test\Options\Options;
 use Kununu\TestingBundle\Tests\App\Fixtures\CachePool\CachePoolFixture3;
 use Psr\Cache\CacheItemPoolInterface;
 
-/**
- * @group legacy
- */
+/** @group legacy */
 final class LoadCacheFixturesCommandTest extends AbstractFixturesCommandTestCase
 {
     private const COMMAND_1 = 'kununu_testing:load_fixtures:cache_pools:app.cache.first';
     private const COMMAND_2 = 'kununu_testing:load_fixtures:cache_pools:app.cache.second';
 
-    /** @var CacheItemPoolInterface */
-    private $cachePool;
+    private CacheItemPoolInterface $cachePool;
 
     protected function doAssertionsForExecuteAppend(): void
     {

--- a/tests/Command/LoadConnectionFixturesCommandTest.php
+++ b/tests/Command/LoadConnectionFixturesCommandTest.php
@@ -5,9 +5,7 @@ namespace Kununu\TestingBundle\Tests\Command;
 
 use Kununu\TestingBundle\Command\LoadConnectionFixturesCommand;
 
-/**
- * @group legacy
- */
+/** @group legacy */
 final class LoadConnectionFixturesCommandTest extends AbstractLoadConnectionTestCase
 {
     private const COMMAND_1 = 'kununu_testing:load_fixtures:connections:def';

--- a/tests/Command/LoadElasticsearchFixturesCommandTest.php
+++ b/tests/Command/LoadElasticsearchFixturesCommandTest.php
@@ -5,95 +5,59 @@ namespace Kununu\TestingBundle\Tests\Command;
 
 use Elasticsearch\Client;
 use Kununu\TestingBundle\Command\LoadElasticsearchFixturesCommand;
-use Kununu\TestingBundle\Test\FixturesAwareTestCase;
 use Kununu\TestingBundle\Test\Options\Options;
 use Kununu\TestingBundle\Tests\App\Fixtures\ElasticSearch\ElasticSearchFixture1;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Exception\CommandNotFoundException;
-use Symfony\Component\Console\Tester\CommandTester;
 
-/**
- * @group legacy
- */
-final class LoadElasticsearchFixturesCommandTest extends FixturesAwareTestCase
+/** @group legacy */
+final class LoadElasticsearchFixturesCommandTest extends AbstractFixturesCommandTestCase
 {
-    /** @var Client */
-    private $elasticsearchClient;
-    /** @var Application */
-    private $application;
+    private const ELASTICSEARCH_CLIENT_ID = 'Kununu\TestingBundle\Tests\App\ElasticSearch';
+    private const COMMAND_1 = 'kununu_testing:load_fixtures:elastic_search:my_index_alias';
+    private const COMMAND_2 = 'kununu_testing:load_fixtures:elastic_search:my_index_alias_2';
 
-    public function testExistsCommands(): void
+    private Client $elasticsearchClient;
+
+    protected function doAssertionsForExecuteAppend(): void
     {
-        $command = $this->application->find('kununu_testing:load_fixtures:elastic_search:my_index_alias');
-        $this->assertInstanceOf(
-            LoadElasticsearchFixturesCommand::class,
-            $command,
-            'Asserted that console command "kununu_testing:load_fixtures:elastic_search:my_index_alias" exists'
-        );
-
-        try {
-            $this->application->find('kununu_testing:load_fixtures:elastic_search:my_index_alias_2');
-            $this->fail('Console command "kununu_testing:load_fixtures:elastic_search:my_index_alias_2" should not exist');
-        } catch (CommandNotFoundException $exception) {
-            $this->assertTrue(true,
-                'Asserted that console command "kununu_testing:load_fixtures:elastic_search:my_index_alias_2" does not exist');
-        }
-    }
-
-    public function testExecuteAppend(): void
-    {
-        $this->prepareToRunCommand();
-
-        $command = $this->application->find('kununu_testing:load_fixtures:elastic_search:my_index_alias');
-        $commandTester = new CommandTester($command);
-        $commandTester->execute([
-            'command'  => $command->getName(),
-            '--append' => null,
-        ]);
-
         $this->assertEquals(2, $this->countDocumentsInIndex());
     }
 
-    public function testExecuteNonAppendInteractive(): void
+    protected function doAssertionsForExecuteNonAppendInteractive(): void
     {
-        $this->prepareToRunCommand();
-
-        $command = $this->application->find('kununu_testing:load_fixtures:elastic_search:my_index_alias');
-        $commandTester = new CommandTester($command);
-        $commandTester->setInputs(['yes']);
-        $commandTester->execute([
-            'command' => $command->getName(),
-        ]);
-
         $this->assertEquals(1, $this->countDocumentsInIndex());
     }
 
-    public function testExecuteNonAppendNonInteractive(): void
+    protected function doAssertionsForExecuteNonAppendNonInteractive(): void
     {
-        $this->prepareToRunCommand();
+        $this->assertEquals(1, $this->countDocumentsInIndex());
+    }
 
-        $command = $this->application->find('kununu_testing:load_fixtures:elastic_search:my_index_alias');
-        $commandTester = new CommandTester($command);
-        $commandTester->execute(
-            ['command' => $command->getName()],
-            ['interactive' => false]
-        );
+    protected function getCommandClass(): string
+    {
+        return LoadElasticsearchFixturesCommand::class;
+    }
+
+    protected function getExistingCommandAlias(): string
+    {
+        return self::COMMAND_1;
+    }
+
+    protected function getNonExistingCommandAliases(): array
+    {
+        return [self::COMMAND_2];
+    }
+
+    protected function preRunCommand(): void
+    {
+        $this->loadElasticSearchFixtures('my_index_alias', Options::create(), ElasticSearchFixture1::class);
 
         $this->assertEquals(1, $this->countDocumentsInIndex());
     }
 
     protected function setUp(): void
     {
-        $kernel = self::bootKernel();
-        $this->application = new Application($kernel);
-        $this->elasticsearchClient = $this->getFixturesContainer()->get('Kununu\TestingBundle\Tests\App\ElasticSearch');
-    }
-
-    private function prepareToRunCommand(): void
-    {
-        $this->loadElasticSearchFixtures('my_index_alias', Options::create(), ElasticSearchFixture1::class);
-
-        $this->assertEquals(1, $this->countDocumentsInIndex());
+        parent::setUp();
+        $this->elasticsearchClient = $this->getFixturesContainer()->get(self::ELASTICSEARCH_CLIENT_ID);
     }
 
     private function countDocumentsInIndex(): int

--- a/tests/Command/LoadNonTransactionalConnectionFixturesCommandTest.php
+++ b/tests/Command/LoadNonTransactionalConnectionFixturesCommandTest.php
@@ -5,9 +5,7 @@ namespace Kununu\TestingBundle\Tests\Command;
 
 use Kununu\TestingBundle\Command\LoadNonTransactionalConnectionFixturesCommand;
 
-/**
- * @group legacy
- */
+/** @group legacy */
 final class LoadNonTransactionalConnectionFixturesCommandTest extends AbstractLoadConnectionTestCase
 {
     private const COMMAND_1 = 'kununu_testing:load_fixtures:non_transactional_connections:def';

--- a/tests/DependencyInjection/CachePoolsConfigurationTest.php
+++ b/tests/DependencyInjection/CachePoolsConfigurationTest.php
@@ -5,7 +5,7 @@ namespace Kununu\TestingBundle\Tests\DependencyInjection;
 
 final class CachePoolsConfigurationTest extends ConfigurationTestCase
 {
-    public function validProcessedConfigurationDataProvider(): array
+    public static function validProcessedConfigurationDataProvider(): array
     {
         return [
             'no_configuration'   => [

--- a/tests/DependencyInjection/Compiler/BaseCompilerPassTestCase.php
+++ b/tests/DependencyInjection/Compiler/BaseCompilerPassTestCase.php
@@ -51,17 +51,7 @@ abstract class BaseCompilerPassTestCase extends AbstractCompilerPassTestCase
         $this->assertTrue($this->container->getDefinition($orchestratorId)->isPublic());
     }
 
-    protected function assertThatDoesNotMatchRegularExpression(string $pattern, string $string, string $message = ''): void
-    {
-        // Support both phpunit ^8.5 and ^9.0 as "assertNotRegExp" is now deprecated
-        if (method_exists($this, 'assertDoesNotMatchRegularExpression')) {
-            $this->assertDoesNotMatchRegularExpression($pattern, $string, $message);
-        } else {
-            $this->assertNotRegExp($pattern, $string, $message);
-        }
-    }
-
-    protected function assertPurger(string $purgerId, string $purgerClass, ...$arguments): void
+    protected function assertPurger(string $purgerId, string $purgerClass, mixed ...$arguments): void
     {
         $this->assertContainerBuilderHasService($purgerId, $purgerClass);
         $this->assertTrue($this->container->getDefinition($purgerId)->isPrivate());
@@ -70,7 +60,7 @@ abstract class BaseCompilerPassTestCase extends AbstractCompilerPassTestCase
         }
     }
 
-    protected function assertExecutor(string $executorId, string $executorClass, ...$arguments): void
+    protected function assertExecutor(string $executorId, string $executorClass, mixed ...$arguments): void
     {
         $this->assertContainerBuilderHasService($executorId, $executorClass);
         $this->assertTrue($this->container->getDefinition($executorId)->isPrivate());
@@ -96,8 +86,16 @@ abstract class BaseCompilerPassTestCase extends AbstractCompilerPassTestCase
     protected function getMockKununuTestingExtension(): ExtensionInterface
     {
         $mock = $this->createMock(ExtensionInterface::class);
-        $mock->expects($this->any())->method('getAlias')->willReturn(KununuTestingExtension::ALIAS);
-        $mock->expects($this->any())->method('getNamespace')->willReturn(false);
+
+        $mock
+            ->expects($this->any())
+            ->method('getAlias')
+            ->willReturn(KununuTestingExtension::ALIAS);
+
+        $mock
+            ->expects($this->any())
+            ->method('getNamespace')
+            ->willReturn(false);
 
         return $mock;
     }

--- a/tests/DependencyInjection/Compiler/BaseConnectionCompilerPassTestCase.php
+++ b/tests/DependencyInjection/Compiler/BaseConnectionCompilerPassTestCase.php
@@ -108,11 +108,11 @@ abstract class BaseConnectionCompilerPassTestCase extends BaseCompilerPassTestCa
 
         $sectionName = $this->getSectionName();
         foreach ($this->container->getServiceIds() as $serviceId) {
-            $this->assertThatDoesNotMatchRegularExpression('/^kununu_testing\.orchestrator\.%s\.\w+$/m', $sectionName, $serviceId);
-            $this->assertThatDoesNotMatchRegularExpression('/^kununu_testing\.orchestrator\.%s\.\w+\.purger$/m', $sectionName, $serviceId);
-            $this->assertThatDoesNotMatchRegularExpression('/^kununu_testing\.orchestrator\.%s\.\w+\.executor/m', $sectionName, $serviceId);
-            $this->assertThatDoesNotMatchRegularExpression('/^kununu_testing\.orchestrator\.%s\.\w+\.loader/m', $sectionName, $serviceId);
-            $this->assertThatDoesNotMatchRegularExpression('/^kununu_testing\.load_fixtures\.%s\.\w+\.command/m', $sectionName, $serviceId);
+            $this->assertDoesNotMatchRegularExpression('/^kununu_testing\.orchestrator\.%s\.\w+$/m', $sectionName, $serviceId);
+            $this->assertDoesNotMatchRegularExpression('/^kununu_testing\.orchestrator\.%s\.\w+\.purger$/m', $sectionName, $serviceId);
+            $this->assertDoesNotMatchRegularExpression('/^kununu_testing\.orchestrator\.%s\.\w+\.executor/m', $sectionName, $serviceId);
+            $this->assertDoesNotMatchRegularExpression('/^kununu_testing\.orchestrator\.%s\.\w+\.loader/m', $sectionName, $serviceId);
+            $this->assertDoesNotMatchRegularExpression('/^kununu_testing\.load_fixtures\.%s\.\w+\.command/m', $sectionName, $serviceId);
         }
     }
 

--- a/tests/DependencyInjection/Compiler/ElasticSearchCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ElasticSearchCompilerPassTest.php
@@ -81,11 +81,11 @@ final class ElasticSearchCompilerPassTest extends BaseCompilerPassTestCase
         $this->compile();
 
         foreach ($this->container->getServiceIds() as $serviceId) {
-            $this->assertThatDoesNotMatchRegularExpression('/^kununu_testing\.orchestrator\.elastic_search\.\w+$/m', $serviceId);
-            $this->assertThatDoesNotMatchRegularExpression('/^kununu_testing\.orchestrator\.elastic_search\.\w+\.purger$/m', $serviceId);
-            $this->assertThatDoesNotMatchRegularExpression('/^kununu_testing\.orchestrator\.elastic_search\.\w+\.executor/m', $serviceId);
-            $this->assertThatDoesNotMatchRegularExpression('/^kununu_testing\.orchestrator\.elastic_search\.\w+\.loader/m', $serviceId);
-            $this->assertThatDoesNotMatchRegularExpression('/^kununu_testing\.load_fixtures\.elastic_search\.\w+\.command/m', $serviceId);
+            $this->assertDoesNotMatchRegularExpression('/^kununu_testing\.orchestrator\.elastic_search\.\w+$/m', $serviceId);
+            $this->assertDoesNotMatchRegularExpression('/^kununu_testing\.orchestrator\.elastic_search\.\w+\.purger$/m', $serviceId);
+            $this->assertDoesNotMatchRegularExpression('/^kununu_testing\.orchestrator\.elastic_search\.\w+\.executor/m', $serviceId);
+            $this->assertDoesNotMatchRegularExpression('/^kununu_testing\.orchestrator\.elastic_search\.\w+\.loader/m', $serviceId);
+            $this->assertDoesNotMatchRegularExpression('/^kununu_testing\.load_fixtures\.elastic_search\.\w+\.command/m', $serviceId);
         }
     }
 

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -5,7 +5,7 @@ namespace Kununu\TestingBundle\Tests\DependencyInjection;
 
 final class ConfigurationTest extends ConfigurationTestCase
 {
-    public function validProcessedConfigurationDataProvider(): array
+    public static function validProcessedConfigurationDataProvider(): array
     {
         return [
             'empty_configuration' => [

--- a/tests/DependencyInjection/ConfigurationTestCase.php
+++ b/tests/DependencyInjection/ConfigurationTestCase.php
@@ -11,26 +11,15 @@ abstract class ConfigurationTestCase extends TestCase
 {
     use ConfigurationTestCaseTrait;
 
-    /**
-     * @dataProvider validProcessedConfigurationDataProvider
-     *
-     * @param array $values
-     * @param array $expectedProcessedConfiguration
-     */
+    /** @dataProvider validProcessedConfigurationDataProvider */
     public function testProcessedConfigurationForNode(array $values, array $expectedProcessedConfiguration): void
     {
         $this->assertProcessedConfigurationEquals($values, $expectedProcessedConfiguration, $this->getNodeName());
     }
 
-    abstract public function validProcessedConfigurationDataProvider(): array;
+    abstract public static function validProcessedConfigurationDataProvider(): array;
 
-    /**
-     * @dataProvider invalidProcessedConfigurationDataProvider
-     *
-     * @param array|null $values
-     *
-     * @return void
-     */
+    /** @dataProvider invalidProcessedConfigurationDataProvider */
     public function testInvalidConfigurationForNode(?array $values): void
     {
         if (null === $values) {
@@ -40,9 +29,9 @@ abstract class ConfigurationTestCase extends TestCase
         }
     }
 
-    public function invalidProcessedConfigurationDataProvider(): ?array
+    public static function invalidProcessedConfigurationDataProvider(): ?array
     {
-        if (empty($data = $this->getInvalidProcessedConfigurationData())) {
+        if (empty($data = static::getInvalidProcessedConfigurationData())) {
             return [
                 'no_tests' => [null],
             ];
@@ -51,7 +40,7 @@ abstract class ConfigurationTestCase extends TestCase
         return $data;
     }
 
-    protected function getInvalidProcessedConfigurationData(): array
+    protected static function getInvalidProcessedConfigurationData(): array
     {
         return [];
     }

--- a/tests/DependencyInjection/ConnectionsConfigurationTest.php
+++ b/tests/DependencyInjection/ConnectionsConfigurationTest.php
@@ -5,7 +5,7 @@ namespace Kununu\TestingBundle\Tests\DependencyInjection;
 
 final class ConnectionsConfigurationTest extends ConfigurationTestCase
 {
-    public function validProcessedConfigurationDataProvider(): array
+    public static function validProcessedConfigurationDataProvider(): array
     {
         return [
             'no_configuration'                                        => [
@@ -140,7 +140,7 @@ final class ConnectionsConfigurationTest extends ConfigurationTestCase
         ];
     }
 
-    protected function getInvalidProcessedConfigurationData(): array
+    protected static function getInvalidProcessedConfigurationData(): array
     {
         return [
             'connections_as_null'        => [

--- a/tests/DependencyInjection/ElasticsearchConfigurationTest.php
+++ b/tests/DependencyInjection/ElasticsearchConfigurationTest.php
@@ -5,7 +5,7 @@ namespace Kununu\TestingBundle\Tests\DependencyInjection;
 
 final class ElasticsearchConfigurationTest extends ConfigurationTestCase
 {
-    public function validProcessedConfigurationDataProvider(): array
+    public static function validProcessedConfigurationDataProvider(): array
     {
         return [
             'no_configuration'   => [
@@ -66,7 +66,7 @@ final class ElasticsearchConfigurationTest extends ConfigurationTestCase
         ];
     }
 
-    protected function getInvalidProcessedConfigurationData(): array
+    protected static function getInvalidProcessedConfigurationData(): array
     {
         return [
             'elastic_search_as_null'        => [

--- a/tests/DependencyInjection/HttpClientConfigurationTest.php
+++ b/tests/DependencyInjection/HttpClientConfigurationTest.php
@@ -5,7 +5,7 @@ namespace Kununu\TestingBundle\Tests\DependencyInjection;
 
 final class HttpClientConfigurationTest extends ConfigurationTestCase
 {
-    public function validProcessedConfigurationDataProvider(): array
+    public static function validProcessedConfigurationDataProvider(): array
     {
         return [
             'no_configuration'   => [

--- a/tests/DependencyInjection/NonTransactionalConnectionsConfigurationTest.php
+++ b/tests/DependencyInjection/NonTransactionalConnectionsConfigurationTest.php
@@ -5,7 +5,7 @@ namespace Kununu\TestingBundle\Tests\DependencyInjection;
 
 final class NonTransactionalConnectionsConfigurationTest extends ConfigurationTestCase
 {
-    public function validProcessedConfigurationDataProvider(): array
+    public static function validProcessedConfigurationDataProvider(): array
     {
         return [
             'no_configuration'                                        => [
@@ -140,7 +140,7 @@ final class NonTransactionalConnectionsConfigurationTest extends ConfigurationTe
         ];
     }
 
-    protected function getInvalidProcessedConfigurationData(): array
+    protected static function getInvalidProcessedConfigurationData(): array
     {
         return [
             'connections_as_null'        => [

--- a/tests/Service/SchemaCopy/Adapter/MySqlAdapterTest.php
+++ b/tests/Service/SchemaCopy/Adapter/MySqlAdapterTest.php
@@ -5,15 +5,14 @@ namespace Kununu\TestingBundle\Tests\Service\SchemaCopy\Adapter;
 
 use Doctrine\DBAL\Connection;
 use Kununu\TestingBundle\Service\SchemaCopy\Adapter\MySqlAdapter;
+use Kununu\TestingBundle\Service\SchemaCopy\SchemaCopyAdapterInterface;
 use Kununu\TestingBundle\Tests\Service\SchemaCopy\SchemaCopyTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
 final class MySqlAdapterTest extends SchemaCopyTestCase
 {
-    /** @var Connection|MockObject */
-    private $connection;
-    /** @var MySqlAdapter */
-    private $adapter;
+    private MockObject|Connection $connection;
+    private SchemaCopyAdapterInterface $adapter;
 
     public function testSameTypeAsEqual(): void
     {

--- a/tests/Service/SchemaCopy/Copier/SchemaCopierTest.php
+++ b/tests/Service/SchemaCopy/Copier/SchemaCopierTest.php
@@ -8,44 +8,49 @@ use Kununu\TestingBundle\Service\SchemaCopy\Adapter\MySqlAdapter;
 use Kununu\TestingBundle\Service\SchemaCopy\Copier\SchemaCopier;
 use Kununu\TestingBundle\Service\SchemaCopy\Exception\IncompatibleAdaptersException;
 use Kununu\TestingBundle\Service\SchemaCopy\SchemaCopyAdapterFactoryInterface;
+use Kununu\TestingBundle\Service\SchemaCopy\SchemaCopyAdapterInterface;
+use Kununu\TestingBundle\Service\SchemaCopy\SchemaCopyInterface;
 use Kununu\TestingBundle\Tests\Service\SchemaCopy\SchemaCopyTestCase;
+use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
 
 final class SchemaCopierTest extends SchemaCopyTestCase
 {
-    /** @var Connection|MockObject */
-    private $source;
-    /** @var Connection|MockObject */
-    private $destination;
-    /** @var SchemaCopyAdapterFactoryInterface|MockObject */
-    private $factory;
-    /** @var SchemaCopier */
-    private $copier;
+    private MockObject|Connection $source;
+    private MockObject|Connection $destination;
+    private MockObject|SchemaCopyAdapterFactoryInterface $factory;
+    private SchemaCopyInterface $copier;
 
     public function testCopy(): void
     {
-        $sourceAdapter = new MySqlAdapter($this->source);
-        $destinationAdapter = new MySqlAdapter($this->destination);
-
         $this->factory
             ->expects($this->exactly(2))
             ->method('createAdapter')
-            ->withConsecutive(
-                [$this->source],
-                [$this->destination]
-            )->willReturnOnConsecutiveCalls(
-                $sourceAdapter,
-                $destinationAdapter
+            ->willReturnCallback(
+                fn(Connection $connection): SchemaCopyAdapterInterface => match ($connection) {
+                    $this->source      => new MySqlAdapter($this->source),
+                    $this->destination => new MySqlAdapter($this->destination),
+                    default            => throw new LogicException('Unknown connection')
+                }
             );
 
         $this->mockExecuteQuery(
             $this->source,
             [
                 $this->createResultMock($this->fetchAllFirstColumnMethod, ['src_table_1', 'src_table_2']),
-                $this->createResultMock($this->fetchNumericMethod, $this->createResultForFetchNumericMethod('[CREATE TABLE src_table_1]')),
-                $this->createResultMock($this->fetchNumericMethod, $this->createResultForFetchNumericMethod('[CREATE TABLE src_table_2]')),
+                $this->createResultMock(
+                    $this->fetchNumericMethod,
+                    $this->createResultForFetchNumericMethod('[CREATE TABLE src_table_1]')
+                ),
+                $this->createResultMock(
+                    $this->fetchNumericMethod,
+                    $this->createResultForFetchNumericMethod('[CREATE TABLE src_table_2]')
+                ),
                 $this->createResultMock($this->fetchAllFirstColumnMethod, ['src_view_1']),
-                $this->createResultMock($this->fetchNumericMethod, $this->createResultForFetchNumericMethod('[CREATE VIEW src_view_1]')),
+                $this->createResultMock(
+                    $this->fetchNumericMethod,
+                    $this->createResultForFetchNumericMethod('[CREATE VIEW src_view_1]')
+                ),
             ],
             'SHOW FULL TABLES WHERE Table_type = \'BASE TABLE\'',
             'SHOW CREATE TABLE `src_table_1`',
@@ -58,7 +63,10 @@ final class SchemaCopierTest extends SchemaCopyTestCase
             $this->destination,
             [
                 $this->createResultMock($this->fetchAllFirstColumnMethod, ['dest_view_1', 'dest_view_2']),
-                $this->createResultMock($this->fetchAllFirstColumnMethod, ['dest_table_1', 'dest_table_2', 'dest_table_3']),
+                $this->createResultMock(
+                    $this->fetchAllFirstColumnMethod,
+                    ['dest_table_1', 'dest_table_2', 'dest_table_3']
+                ),
             ],
             'SHOW FULL TABLES WHERE Table_type = \'VIEW\'',
             'SHOW FULL TABLES WHERE Table_type = \'BASE TABLE\''
@@ -85,22 +93,21 @@ final class SchemaCopierTest extends SchemaCopyTestCase
 
     public function testCopyWithIncompatibleAdapters(): void
     {
-        $sourceAdapter = new MySqlAdapter($this->source);
-        $destinationAdapter = $this->createAdapterMock('YourSql', 2);
-
         $this->factory
             ->expects($this->exactly(2))
             ->method('createAdapter')
-            ->withConsecutive(
-                [$this->source],
-                [$this->destination]
-            )->willReturnOnConsecutiveCalls(
-                $sourceAdapter,
-                $destinationAdapter
+            ->willReturnCallback(
+                fn(Connection $connection): SchemaCopyAdapterInterface => match ($connection) {
+                    $this->source      => new MySqlAdapter($this->source),
+                    $this->destination => $this->createAdapterMock('YourSql', 2),
+                    default            => throw new LogicException('Unknown connection')
+                }
             );
 
         $this->expectException(IncompatibleAdaptersException::class);
-        $this->expectExceptionMessage('Source and destination adapters must be of the same type! Source: MySql Destination: YourSql');
+        $this->expectExceptionMessage(
+            'Source and destination adapters must be of the same type! Source: MySql Destination: YourSql'
+        );
 
         $this->copier->copy($this->source, $this->destination);
     }

--- a/tests/Service/SchemaCopy/Factory/AdapterFactoryTest.php
+++ b/tests/Service/SchemaCopy/Factory/AdapterFactoryTest.php
@@ -12,12 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 final class AdapterFactoryTest extends TestCase
 {
-    /**
-     * @dataProvider createAdapterDataProvider
-     *
-     * @param string      $platformClass
-     * @param string|null $expectedType
-     */
+    /** @dataProvider createAdapterDataProvider */
     public function testCreateAdapter(string $platformClass, ?string $expectedType): void
     {
         $connection = $this->createMock(Connection::class);
@@ -37,7 +32,7 @@ final class AdapterFactoryTest extends TestCase
         }
     }
 
-    public function createAdapterDataProvider(): array
+    public static function createAdapterDataProvider(): array
     {
         return [
             'mysql'   => [

--- a/tests/Test/FixturesAwareTestCaseCachePoolTest.php
+++ b/tests/Test/FixturesAwareTestCaseCachePoolTest.php
@@ -9,24 +9,15 @@ use Kununu\TestingBundle\Tests\App\Fixtures\CachePool\CachePoolFixture1;
 use Kununu\TestingBundle\Tests\App\Fixtures\CachePool\CachePoolFixture2;
 use Psr\Cache\CacheItemPoolInterface;
 
-/**
- * @group legacy
- */
+/** @group legacy */
 final class FixturesAwareTestCaseCachePoolTest extends FixturesAwareTestCase
 {
     private const EXTRA_DATA_FOR_INIT = 'some extra data for init';
 
-    /** @var CacheItemPoolInterface */
-    private $cachePool;
-
-    /** @var CacheItemPoolInterface */
-    private $tagAwareCachePool;
-
-    /** @var CacheItemPoolInterface */
-    private $tagAwarePoolCachePool;
-
-    /** @var CacheItemPoolInterface */
-    private $chainCachePool;
+    private CacheItemPoolInterface $cachePool;
+    private CacheItemPoolInterface $tagAwareCachePool;
+    private CacheItemPoolInterface $tagAwarePoolCachePool;
+    private CacheItemPoolInterface $chainCachePool;
 
     public function testLoadCachePoolFixturesWithoutAppend(): void
     {
@@ -39,7 +30,12 @@ final class FixturesAwareTestCaseCachePoolTest extends FixturesAwareTestCase
             CachePoolFixture1::class,
             self::EXTRA_DATA_FOR_INIT
         );
-        $this->loadCachePoolFixtures('app.cache.first', Options::create(), CachePoolFixture1::class, CachePoolFixture2::class);
+        $this->loadCachePoolFixtures(
+            'app.cache.first',
+            Options::create(),
+            CachePoolFixture1::class,
+            CachePoolFixture2::class
+        );
 
         $cachePool1ItemAfterPurge1 = $this->cachePool->getItem('cache_pool_1_key_to_purge_1');
         $cachePool1Item1 = $this->cachePool->getItem('key_1');
@@ -89,7 +85,12 @@ final class FixturesAwareTestCaseCachePoolTest extends FixturesAwareTestCase
             self::EXTRA_DATA_FOR_INIT
         );
 
-        $this->loadCachePoolFixtures('app.cache.third', Options::create(), CachePoolFixture1::class, CachePoolFixture2::class);
+        $this->loadCachePoolFixtures(
+            'app.cache.third',
+            Options::create(),
+            CachePoolFixture1::class,
+            CachePoolFixture2::class
+        );
 
         $cachePool1ItemAfterPurge1 = $this->tagAwareCachePool->getItem('cache_pool_1_key_to_purge_1');
         $cachePool1Item1 = $this->tagAwareCachePool->getItem('key_1');
@@ -139,7 +140,12 @@ final class FixturesAwareTestCaseCachePoolTest extends FixturesAwareTestCase
             self::EXTRA_DATA_FOR_INIT
         );
 
-        $this->loadCachePoolFixtures('app.cache.fourth', Options::create(), CachePoolFixture1::class, CachePoolFixture2::class);
+        $this->loadCachePoolFixtures(
+            'app.cache.fourth',
+            Options::create(),
+            CachePoolFixture1::class,
+            CachePoolFixture2::class
+        );
 
         $cachePool1ItemAfterPurge1 = $this->tagAwarePoolCachePool->getItem('cache_pool_1_key_to_purge_1');
         $cachePool1Item1 = $this->tagAwarePoolCachePool->getItem('key_1');
@@ -189,7 +195,12 @@ final class FixturesAwareTestCaseCachePoolTest extends FixturesAwareTestCase
             self::EXTRA_DATA_FOR_INIT
         );
 
-        $this->loadCachePoolFixtures('app.cache.fifth', Options::create(), CachePoolFixture1::class, CachePoolFixture2::class);
+        $this->loadCachePoolFixtures(
+            'app.cache.fifth',
+            Options::create(),
+            CachePoolFixture1::class,
+            CachePoolFixture2::class
+        );
 
         $cachePool1ItemAfterPurge1 = $this->chainCachePool->getItem('cache_pool_1_key_to_purge_1');
         $cachePool1Item1 = $this->chainCachePool->getItem('key_1');
@@ -228,15 +239,18 @@ final class FixturesAwareTestCaseCachePoolTest extends FixturesAwareTestCase
 
     public function testClearFixtures(): void
     {
-        $this->loadCachePoolFixtures('app.cache.fifth', Options::create(), CachePoolFixture1::class, CachePoolFixture2::class);
+        $this->loadCachePoolFixtures(
+            'app.cache.fifth',
+            Options::create(),
+            CachePoolFixture1::class,
+            CachePoolFixture2::class
+        );
         $this->clearCachePoolFixtures('app.cache.fifth');
         $this->assertEmpty($this->getCachePoolFixtures('app.cache.fifth'));
     }
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->cachePool = $this->getFixturesContainer()->get('app.cache.first');
         $this->tagAwareCachePool = $this->getFixturesContainer()->get('app.cache.third');
         $this->tagAwarePoolCachePool = $this->getFixturesContainer()->get('app.cache.fourth');

--- a/tests/Test/FixturesAwareTestCaseConnectionsTest.php
+++ b/tests/Test/FixturesAwareTestCaseConnectionsTest.php
@@ -10,18 +10,13 @@ use Kununu\TestingBundle\Tests\App\Fixtures\Connection\ConnectionFixture1;
 use Kununu\TestingBundle\Tests\App\Fixtures\Connection\ConnectionSqlFixture1;
 use Kununu\TestingBundle\Traits\ConnectionToolsTrait;
 
-/**
- * @group legacy
- */
+/** @group legacy */
 final class FixturesAwareTestCaseConnectionsTest extends FixturesAwareTestCase
 {
     use ConnectionToolsTrait;
 
-    /** @var Connection */
-    private $defConnection;
-
-    /** @var Connection */
-    private $monolithicConnection;
+    private Connection $defConnection;
+    private Connection $monolithicConnection;
 
     public function testLoadDbFixturesWithAppend(): void
     {
@@ -54,13 +49,16 @@ final class FixturesAwareTestCaseConnectionsTest extends FixturesAwareTestCase
             ConnectionSqlFixture1::class
         );
 
-        $this->assertEquals(4, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM table_1'));
+        $this->assertEquals(4, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM `table_1`'));
         $this->assertEquals(4, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM table_2'));
-        $this->assertEquals(1, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM table_to_exclude'));
+        $this->assertEquals(1, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM `table_to_exclude`'));
 
         $this->assertEquals(4, (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM table_1'));
         $this->assertEquals(4, (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM table_2'));
-        $this->assertEquals(1, (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM table_to_exclude'));
+        $this->assertEquals(
+            1,
+            (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM table_to_exclude')
+        );
     }
 
     public function testLoadDbFixturesWithoutAppend(): void
@@ -81,13 +79,16 @@ final class FixturesAwareTestCaseConnectionsTest extends FixturesAwareTestCase
             ConnectionSqlFixture1::class
         );
 
-        $this->assertEquals(3, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM table_1'));
+        $this->assertEquals(3, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM `table_1`'));
         $this->assertEquals(3, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM table_2'));
         $this->assertEquals(1, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM table_to_exclude'));
 
         $this->assertEquals(3, (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM table_1'));
         $this->assertEquals(3, (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM table_2'));
-        $this->assertEquals(1, (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM table_to_exclude'));
+        $this->assertEquals(
+            1,
+            (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM table_to_exclude')
+        );
     }
 
     public function testClearFixtures(): void
@@ -115,10 +116,22 @@ final class FixturesAwareTestCaseConnectionsTest extends FixturesAwareTestCase
             $this->executeQuery($connection, 'TRUNCATE `table_2`');
             $this->executeQuery($connection, 'TRUNCATE `table_3`');
             $this->executeQuery($connection, 'TRUNCATE `table_to_exclude`');
-            $this->executeQuery($connection, 'INSERT INTO `table_1` (`name`, `description`) VALUES (\'name\', \'description\');');
-            $this->executeQuery($connection, 'INSERT INTO `table_2` (`name`, `description`) VALUES (\'name\', \'description\');');
-            $this->executeQuery($connection, 'INSERT INTO `table_3` (`name`, `description`) VALUES (\'name\', \'description\');');
-            $this->executeQuery($connection, 'INSERT INTO `table_to_exclude` (`name`, `description`) VALUES (\'name\', \'description\');');
+            $this->executeQuery(
+                $connection,
+                'INSERT INTO `table_1` (`name`, `description`) VALUES (\'name\', \'description\');'
+            );
+            $this->executeQuery(
+                $connection,
+                'INSERT INTO `table_2` (`name`, `description`) VALUES (\'name\', \'description\');'
+            );
+            $this->executeQuery(
+                $connection,
+                'INSERT INTO `table_3` (`name`, `description`) VALUES (\'name\', \'description\');'
+            );
+            $this->executeQuery(
+                $connection,
+                'INSERT INTO `table_to_exclude` (`name`, `description`) VALUES (\'name\', \'description\');'
+            );
         }
     }
 }

--- a/tests/Test/FixturesAwareTestCaseHttpClientTest.php
+++ b/tests/Test/FixturesAwareTestCaseHttpClientTest.php
@@ -11,25 +11,32 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-/**
- * @group legacy
- */
+/** @group legacy */
 final class FixturesAwareTestCaseHttpClientTest extends FixturesAwareTestCase
 {
-    /** @var HttpClientInterface */
-    private $httpClient;
+    private HttpClientInterface $httpClient;
 
     public function testLoadHttpClientFixturesWithAppend(): void
     {
         $this->registerInitializableFixtureForHttpClient('http_client', HttpClientFixture1::class);
 
-        $this->loadHttpClientFixtures('http_client', $options = Options::create()->withAppend(), HttpClientFixture1::class);
+        $this->loadHttpClientFixtures(
+            'http_client',
+            $options = Options::create()->withAppend(),
+            HttpClientFixture1::class
+        );
         $this->loadHttpClientFixtures('http_client', $options, HttpClientFixture2::class);
 
-        $response = $this->httpClient->request(Request::METHOD_GET, 'https://my.server/b7dd0cc2-381d-4e92-bc9b-b78245142e0a/data');
+        $response = $this->httpClient->request(
+            Request::METHOD_GET,
+            'https://my.server/b7dd0cc2-381d-4e92-bc9b-b78245142e0a/data'
+        );
         $this->assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
 
-        $response = $this->httpClient->request(Request::METHOD_GET, 'https://my.server/f2895c23-28cb-4020-b038-717cca64bf2d/data');
+        $response = $this->httpClient->request(
+            Request::METHOD_GET,
+            'https://my.server/f2895c23-28cb-4020-b038-717cca64bf2d/data'
+        );
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertJsonStringEqualsJsonString(
             <<<'JSON'
@@ -53,10 +60,16 @@ JSON
         $this->loadHttpClientFixtures('http_client', $options = Options::create(), HttpClientFixture1::class);
         $this->loadHttpClientFixtures('http_client', $options, HttpClientFixture2::class);
 
-        $response = $this->httpClient->request(Request::METHOD_GET, 'https://my.server/b7dd0cc2-381d-4e92-bc9b-b78245142e0a/data');
+        $response = $this->httpClient->request(
+            Request::METHOD_GET,
+            'https://my.server/b7dd0cc2-381d-4e92-bc9b-b78245142e0a/data'
+        );
         $this->assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
 
-        $response = $this->httpClient->request(Request::METHOD_GET, 'https://my.server/f2895c23-28cb-4020-b038-717cca64bf2d/data');
+        $response = $this->httpClient->request(
+            Request::METHOD_GET,
+            'https://my.server/f2895c23-28cb-4020-b038-717cca64bf2d/data'
+        );
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertJsonStringEqualsJsonString(
             <<<'JSON'
@@ -77,7 +90,12 @@ JSON
 
     public function testClearFixtures(): void
     {
-        $this->loadHttpClientFixtures('http_client', Options::create(), HttpClientFixture1::class, HttpClientFixture2::class);
+        $this->loadHttpClientFixtures(
+            'http_client',
+            Options::create(),
+            HttpClientFixture1::class,
+            HttpClientFixture2::class
+        );
         $this->clearHttpClientFixtures('http_client');
         $this->assertEmpty($this->getHttpClientFixtures('http_client'));
     }

--- a/tests/Test/FixturesAwareTestCaseNonTransactionalConnectionsTest.php
+++ b/tests/Test/FixturesAwareTestCaseNonTransactionalConnectionsTest.php
@@ -10,18 +10,13 @@ use Kununu\TestingBundle\Tests\App\Fixtures\Connection\ConnectionFixture1;
 use Kununu\TestingBundle\Tests\App\Fixtures\Connection\ConnectionSqlFixture1;
 use Kununu\TestingBundle\Traits\ConnectionToolsTrait;
 
-/**
- * @group legacy
- */
+/** @group legacy */
 final class FixturesAwareTestCaseNonTransactionalConnectionsTest extends FixturesAwareTestCase
 {
     use ConnectionToolsTrait;
 
-    /** @var Connection */
-    private $defConnection;
-
-    /** @var Connection */
-    private $monolithicConnection;
+    private Connection $defConnection;
+    private Connection $monolithicConnection;
 
     public function testLoadDbFixturesWithAppend(): void
     {
@@ -54,13 +49,16 @@ final class FixturesAwareTestCaseNonTransactionalConnectionsTest extends Fixture
             ConnectionSqlFixture1::class
         );
 
-        $this->assertEquals(4, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM table_1'));
+        $this->assertEquals(4, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM `table_1`'));
         $this->assertEquals(4, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM table_2'));
-        $this->assertEquals(1, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM table_to_exclude'));
+        $this->assertEquals(1, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM `table_to_exclude`'));
 
-        $this->assertEquals(4, (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM table_1'));
+        $this->assertEquals(4, (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM `table_1`'));
         $this->assertEquals(4, (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM table_2'));
-        $this->assertEquals(1, (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM table_to_exclude'));
+        $this->assertEquals(
+            1,
+            (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM table_to_exclude')
+        );
     }
 
     public function testLoadDbFixturesWithoutAppend(): void
@@ -81,13 +79,16 @@ final class FixturesAwareTestCaseNonTransactionalConnectionsTest extends Fixture
             ConnectionSqlFixture1::class
         );
 
-        $this->assertEquals(3, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM table_1'));
-        $this->assertEquals(3, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM table_2'));
+        $this->assertEquals(3, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM `table_1`'));
+        $this->assertEquals(3, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM `table_2`'));
         $this->assertEquals(1, (int) $this->fetchOne($this->defConnection, 'SELECT COUNT(*) FROM table_to_exclude'));
 
         $this->assertEquals(3, (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM table_1'));
         $this->assertEquals(3, (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM table_2'));
-        $this->assertEquals(1, (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM table_to_exclude'));
+        $this->assertEquals(
+            1,
+            (int) $this->fetchOne($this->monolithicConnection, 'SELECT COUNT(*) FROM table_to_exclude')
+        );
     }
 
     public function testClearFixtures(): void
@@ -114,10 +115,22 @@ final class FixturesAwareTestCaseNonTransactionalConnectionsTest extends Fixture
             $this->executeQuery($connection, 'TRUNCATE `table_2`');
             $this->executeQuery($connection, 'TRUNCATE `table_3`');
             $this->executeQuery($connection, 'TRUNCATE `table_to_exclude`');
-            $this->executeQuery($connection, 'INSERT INTO `table_1` (`name`, `description`) VALUES (\'name\', \'description\');');
-            $this->executeQuery($connection, 'INSERT INTO `table_2` (`name`, `description`) VALUES (\'name\', \'description\');');
-            $this->executeQuery($connection, 'INSERT INTO `table_3` (`name`, `description`) VALUES (\'name\', \'description\');');
-            $this->executeQuery($connection, 'INSERT INTO `table_to_exclude` (`name`, `description`) VALUES (\'name\', \'description\');');
+            $this->executeQuery(
+                $connection,
+                'INSERT INTO `table_1` (`name`, `description`) VALUES (\'name\', \'description\');'
+            );
+            $this->executeQuery(
+                $connection,
+                'INSERT INTO `table_2` (`name`, `description`) VALUES (\'name\', \'description\');'
+            );
+            $this->executeQuery(
+                $connection,
+                'INSERT INTO `table_3` (`name`, `description`) VALUES (\'name\', \'description\');'
+            );
+            $this->executeQuery(
+                $connection,
+                'INSERT INTO `table_to_exclude` (`name`, `description`) VALUES (\'name\', \'description\');'
+            );
         }
     }
 }

--- a/tests/Test/Options/DbOptionsTest.php
+++ b/tests/Test/Options/DbOptionsTest.php
@@ -9,16 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class DbOptionsTest extends TestCase
 {
-    /**
-     * @dataProvider dbOptionsDataProvider
-     *
-     * @param DbOptionsInterface $options
-     * @param bool               $expectedAppend
-     * @param bool               $expectedClear
-     * @param bool               $expectedTransactional
-     *
-     * @return void
-     */
+    /** @dataProvider dbOptionsDataProvider */
     public function testDbOptions(DbOptionsInterface $options, bool $expectedAppend, bool $expectedClear, bool $expectedTransactional): void
     {
         $this->assertEquals($expectedAppend, $options->append());
@@ -26,7 +17,7 @@ final class DbOptionsTest extends TestCase
         $this->assertEquals($expectedTransactional, $options->transactional());
     }
 
-    public function dbOptionsDataProvider(): array
+    public static function dbOptionsDataProvider(): array
     {
         return [
             'default'                               => [

--- a/tests/Test/Options/OptionsTest.php
+++ b/tests/Test/Options/OptionsTest.php
@@ -9,22 +9,14 @@ use PHPUnit\Framework\TestCase;
 
 final class OptionsTest extends TestCase
 {
-    /**
-     * @dataProvider optionsDataProvider
-     *
-     * @param OptionsInterface $options
-     * @param bool             $expectedAppend
-     * @param bool             $expectedClear
-     *
-     * @return void
-     */
+    /** @dataProvider optionsDataProvider */
     public function testOptions(OptionsInterface $options, bool $expectedAppend, bool $expectedClear): void
     {
         $this->assertEquals($expectedAppend, $options->append());
         $this->assertEquals($expectedClear, $options->clear());
     }
 
-    public function optionsDataProvider(): array
+    public static function optionsDataProvider(): array
     {
         return [
             'default'               => [

--- a/tests/Test/RequestBuilderTest.php
+++ b/tests/Test/RequestBuilderTest.php
@@ -132,9 +132,7 @@ final class RequestBuilderTest extends TestCase
         $this->assertEquals('Bearer ACCESS_TOKEN_VALUE', $server['HTTP_AUTHORIZATION']);
     }
 
-    /**
-     * @dataProvider buildRequestWithHeaderDataProvider
-     */
+    /** @dataProvider buildRequestWithHeaderDataProvider */
     public function testBuildRequestWithHeader(string $headerName, string $expectedHeaderName): void
     {
         $headerValue = 'value';
@@ -145,7 +143,7 @@ final class RequestBuilderTest extends TestCase
         $this->assertEquals($headerValue, $server[$expectedHeaderName]);
     }
 
-    public function buildRequestWithHeaderDataProvider(): array
+    public static function buildRequestWithHeaderDataProvider(): array
     {
         return [
             'with_http'    => [

--- a/tests/Test/WebTestCaseTest.php
+++ b/tests/Test/WebTestCaseTest.php
@@ -7,9 +7,7 @@ use Kununu\TestingBundle\Test\FixturesAwareTestCase;
 use Kununu\TestingBundle\Test\RequestBuilder;
 use Kununu\TestingBundle\Test\WebTestCase;
 
-/**
- * @group legacy
- */
+/** @group legacy */
 final class WebTestCaseTest extends WebTestCase
 {
     public function testDoRequest(): void


### PR DESCRIPTION
# Description

The objective of this PR is to drop support for PHP 7.x as all of those versions are already out of support and to allow future developments not be constrained by those old versions.

## Details

- Drop support for PHP 7.x
- Small refactors to use PHP 8.0 features and optimize some code