### PR TITLE
Fix kernel already booted in WebTestCase::doRequest

### DIFF
--- a/src/Test/AbstractTestCase.php
+++ b/src/Test/AbstractTestCase.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\TestingBundle\Test;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+abstract class AbstractTestCase extends WebTestCase
+{
+    protected ?KernelBrowser $kernelBrowser = null;
+
+    final protected function getFixturesContainer(): ContainerInterface
+    {
+        if (
+            !static::$kernel ||
+            !(method_exists(static::class, 'getContainer') ? static::getContainer() : static::$container)
+        ) {
+            $this->getKernelBrowser();
+        }
+
+        return method_exists(static::class, 'getContainer') ? static::getContainer() : static::$container;
+    }
+
+    final protected function getKernelBrowser(): KernelBrowser
+    {
+        if (!$this->kernelBrowser) {
+            $this->kernelBrowser = static::createClient();
+        }
+
+        return $this->kernelBrowser;
+    }
+
+    final protected function shutdown(): void
+    {
+        $this->kernelBrowser = null;
+        $this->ensureKernelShutdown();
+    }
+}

--- a/src/Test/FixturesAwareTestCase.php
+++ b/src/Test/FixturesAwareTestCase.php
@@ -6,14 +6,9 @@ namespace Kununu\TestingBundle\Test;
 use Kununu\TestingBundle\Service\Orchestrator;
 use Kununu\TestingBundle\Test\Options\DbOptionsInterface;
 use Kununu\TestingBundle\Test\Options\OptionsInterface;
-use Psr\Container\ContainerInterface;
-use Symfony\Bundle\FrameworkBundle\KernelBrowser;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 
-abstract class FixturesAwareTestCase extends BaseWebTestCase
+abstract class FixturesAwareTestCase extends AbstractTestCase
 {
-    protected ?KernelBrowser $kernelBrowser = null;
-
     private const KEY_CONNECTIONS = 'connections';
     private const KEY_NON_TRANSACTIONAL_CONNECTIONS = 'non_transactional_connections';
     private const KEY_CACHE_POOLS = 'cache_pools';
@@ -113,18 +108,6 @@ abstract class FixturesAwareTestCase extends BaseWebTestCase
             ->registerInitializableFixture($className, ...$args);
     }
 
-    final protected function getFixturesContainer(): ContainerInterface
-    {
-        if (
-            !static::$kernel ||
-            !(method_exists(static::class, 'getContainer') ? static::getContainer() : static::$container)
-        ) {
-            $this->getKernelBrowser();
-        }
-
-        return method_exists(static::class, 'getContainer') ? static::getContainer() : static::$container;
-    }
-
     final protected function clearDbFixtures(string $connectionName, DbOptionsInterface $options): self
     {
         $this
@@ -181,21 +164,6 @@ abstract class FixturesAwareTestCase extends BaseWebTestCase
     final protected function getHttpClientFixtures(string $httpClientServiceId): array
     {
         return $this->getOrchestrator(self::KEY_HTTP_CLIENT, $httpClientServiceId)->getFixtures();
-    }
-
-    final protected function getKernelBrowser(): KernelBrowser
-    {
-        if (!$this->kernelBrowser) {
-            $this->kernelBrowser = static::createClient();
-        }
-
-        return $this->kernelBrowser;
-    }
-
-    final protected function shutdown(): void
-    {
-        $this->kernelBrowser = null;
-        $this->ensureKernelShutdown();
     }
 
     private function getOrchestrator(string $type, string $key): Orchestrator

--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -3,20 +3,17 @@ declare(strict_types=1);
 
 namespace Kununu\TestingBundle\Test;
 
-use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Response;
 
 abstract class WebTestCase extends FixturesAwareTestCase
 {
-    private ?KernelBrowser $client = null;
-
     final protected function doRequest(RequestBuilder $builder, bool $shutdown = true): Response
     {
-        $this->initClient();
+        $client = $this->getKernelBrowser();
 
-        $this->client->request(...$builder->build());
+        $client->request(...$builder->build());
 
-        $response = $this->client->getResponse();
+        $response = $client->getResponse();
 
         // Since there is no content, then there is also no content-type header.
         if (Response::HTTP_NO_CONTENT !== $response->getStatusCode()) {
@@ -29,16 +26,9 @@ abstract class WebTestCase extends FixturesAwareTestCase
         }
 
         if ($shutdown) {
-            $this->ensureKernelShutdown();
+            $this->shutdown();
         }
 
         return $response;
-    }
-
-    private function initClient(): void
-    {
-        if (!$this->client) {
-            $this->client = static::createClient();
-        }
     }
 }


### PR DESCRIPTION
# Description

The objective of this PR is to fix an issue when calling `WebTestCase::doRequest` after already loading fixtures in Symfony 5.x.

This would fail with a message stating that the kernel was already booted and the BrowserKit client could not be created.

## Details
- Fix problem in Symfony 5.x where calling WebTestCase::doRequest would fail stating that kernel was already booted (e.g. if you used `getFixturesContainer` before doing the `doRequest` call)
  - Move internal BrowserKit client to `FixturesAwareTestCase` and initialize it in `getFixturesContainer`
  - Expose the KernelBrowser client in`FixturesAwareTestCase` via protected method `getKernelBrowser`
  - On `WebTestCase` use the `getKernelBrowser` when executing the `doRequest` method. This way if the client was already initialized (and the kernel booted) it will no longer be created again. If client is not initialized the it will boot the kernel
