### PR TITLE
Fix again the kernel already booted in WebTestCase::doRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,8 @@ public function withServerParameter(string $parameterName, string $parameterValu
 This bundle exposes the [WebTestCase](https://github.com/kununu/testing-bundle/blob/master/src/Test/WebTestCase.php) that you can extend which exposes a method that helps you testing your controllers without having to care about create the kernel. This class also allows you load fixtures in your tests.
 
 ```php
-final protected function doRequest(RequestBuilder $builder, bool $shutdown = true): Symfony\Component\HttpFoundation\Response
+final protected function doRequest(RequestBuilder $builder): Symfony\Component\HttpFoundation\Response
 ```
-
-The `shutdown` parameter, if set to true (default), will ensure that Symfony kernel is shutdown after the request, which is required to avoid exceptions on Symfony 5 and up.
 
 Internally this method calls the Symfony client with:
 

--- a/src/Test/AbstractTestCase.php
+++ b/src/Test/AbstractTestCase.php
@@ -34,7 +34,7 @@ abstract class AbstractTestCase extends WebTestCase
 
     final protected function shutdown(): void
     {
-        $this->kernelBrowser = null;
         $this->ensureKernelShutdown();
+        $this->kernelBrowser = null;
     }
 }

--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -7,8 +7,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 abstract class WebTestCase extends FixturesAwareTestCase
 {
-    final protected function doRequest(RequestBuilder $builder, bool $shutdown = true): Response
+    final protected function doRequest(RequestBuilder $builder): Response
     {
+        $this->shutdown();
+
         $client = $this->getKernelBrowser();
 
         $client->request(...$builder->build());
@@ -23,10 +25,6 @@ abstract class WebTestCase extends FixturesAwareTestCase
                     'application/json'
                 )
             );
-        }
-
-        if ($shutdown) {
-            $this->shutdown();
         }
 
         return $response;


### PR DESCRIPTION
# Description

The objective of this PR is to continue https://github.com/kununu/testing-bundle/pull/45. Still having issues when calling WebTestCase::doRequest in Symfony 5.x giving the error.

## Details
- Ensure kernel is shutdown and interlnal KernelBrowser is recreated when calling `doRequest`