### PR TITLE
Fixes http fixture issues with Kernel shutdown

### DIFF
--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -3,15 +3,26 @@ declare(strict_types=1);
 
 namespace Kununu\TestingBundle\Test;
 
+use Kununu\TestingBundle\Test\Options\Options;
 use Symfony\Component\HttpFoundation\Response;
 
 abstract class WebTestCase extends FixturesAwareTestCase
 {
-    final protected function doRequest(RequestBuilder $builder): Response
+    final protected function doRequest(RequestBuilder $builder, string $httpClientName = 'http_client', ?Options $options = null): Response
     {
+        $httpClientFixtures = $this->getHttpClientFixtures($httpClientName);
+
+        if (!$options) {
+            $options = Options::create();
+        }
+
         $this->shutdown();
 
         $client = $this->getKernelBrowser();
+
+        foreach ($httpClientFixtures as $fixtureClass => $fixture) {
+            $this->loadHttpClientFixtures($httpClientName, $options, $fixtureClass);
+        }
 
         $client->request(...$builder->build());
 

--- a/tests/Test/DataFixtures/Responses/WebTestCaseFixtures/fixtures.php
+++ b/tests/Test/DataFixtures/Responses/WebTestCaseFixtures/fixtures.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+return [
+    // HTTP GET to check reload after kernel shutdown
+    [
+        'url'    => '/test-http-fixtures',
+        'body'   => <<<'JSON'
+{
+}
+JSON,
+    ],
+];

--- a/tests/Test/DataFixtures/WebTestCaseFixtures.php
+++ b/tests/Test/DataFixtures/WebTestCaseFixtures.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\TestingBundle\Tests\Test\DataFixtures;
+
+use Kununu\DataFixtures\Adapter\DirectoryLoader\HttpClientArrayDirectoryFixture;
+
+final class WebTestCaseFixtures extends HttpClientArrayDirectoryFixture
+{
+}

--- a/tests/Test/WebTestCaseTest.php
+++ b/tests/Test/WebTestCaseTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 namespace Kununu\TestingBundle\Tests\Test;
 
 use Kununu\TestingBundle\Test\FixturesAwareTestCase;
+use Kununu\TestingBundle\Test\Options\Options;
 use Kununu\TestingBundle\Test\RequestBuilder;
 use Kununu\TestingBundle\Test\WebTestCase;
+use Kununu\TestingBundle\Tests\Test\DataFixtures\WebTestCaseFixtures;
 
 /** @group legacy */
 final class WebTestCaseTest extends WebTestCase
@@ -22,5 +24,16 @@ final class WebTestCaseTest extends WebTestCase
     public function testThatExtendsFixturesAwareTestCase(): void
     {
         $this->assertTrue(is_subclass_of($this, FixturesAwareTestCase::class));
+    }
+
+    public function testThatHttpFixturesGetLoaded(): void
+    {
+        $this->loadHttpClientFixtures('http_client', Options::create(), WebTestCaseFixtures::class);
+
+        $this->doRequest(
+            RequestBuilder::aGetRequest()->withUri('/app/response')
+        );
+
+        $this->assertNotEmpty($this->getHttpClientFixtures('http_client'));
     }
 }


### PR DESCRIPTION
## What's Changed
* Fix kernel reboot losing http fixtures
  - Fix problem in Symfony 5.x where calling WebTestCase::doRequest would lose the loaded http fixtures

