### PR TITLE
Do not reload HTTP client fixtures on WebTestCase if no HTTP client fixtures are available

### DIFF
--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -4,18 +4,16 @@ declare(strict_types=1);
 namespace Kununu\TestingBundle\Test;
 
 use Kununu\TestingBundle\Test\Options\Options;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 abstract class WebTestCase extends FixturesAwareTestCase
 {
     final protected function doRequest(RequestBuilder $builder, string $httpClientName = 'http_client', ?Options $options = null): Response
     {
-        try {
-            $httpClientFixtures = $this->getHttpClientFixtures($httpClientName);
-        } catch (ServiceNotFoundException) {
-            $httpClientFixtures = null;
-        }
+        $httpClientFixtures = interface_exists(HttpClientInterface::class)
+            ? $this->getHttpClientFixtures($httpClientName)
+            : null;
 
         $this->shutdown();
 

--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -4,24 +4,25 @@ declare(strict_types=1);
 namespace Kununu\TestingBundle\Test;
 
 use Kununu\TestingBundle\Test\Options\Options;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\Response;
 
 abstract class WebTestCase extends FixturesAwareTestCase
 {
     final protected function doRequest(RequestBuilder $builder, string $httpClientName = 'http_client', ?Options $options = null): Response
     {
-        $httpClientFixtures = $this->getHttpClientFixtures($httpClientName);
-
-        if (!$options) {
-            $options = Options::create();
+        try {
+            $httpClientFixtures = $this->getHttpClientFixtures($httpClientName);
+        } catch (ServiceNotFoundException) {
+            $httpClientFixtures = null;
         }
 
         $this->shutdown();
 
         $client = $this->getKernelBrowser();
 
-        foreach ($httpClientFixtures as $fixtureClass => $fixture) {
-            $this->loadHttpClientFixtures($httpClientName, $options, $fixtureClass);
+        foreach ($httpClientFixtures ?? [] as $fixtureClass => $fixture) {
+            $this->loadHttpClientFixtures($httpClientName, $options ?? Options::create(), $fixtureClass);
         }
 
         $client->request(...$builder->build());


### PR DESCRIPTION
# Description

The objective of this PR is to make sure that WebTestCase doesn't throw a ServiceNotFoundException if symfony/http-client is not installed
