### PR TITLE
Update continuous integration components

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build:
     name: PHPUnit
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         php-version:
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -64,7 +64,7 @@ jobs:
           extensions: ${{ matrix.extensions }}
 
       - name: Install Composer Dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
         with:
           dependency-versions: ${{ matrix.dependencies }}
           composer-options: "--prefer-stable"
@@ -88,23 +88,23 @@ jobs:
           DATABASE_SERVER_VERSION: ${{ matrix.mysql-version }}
 
       - name: Upload coverage files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.job }}-${{ matrix.php-version }}-coverage
+          name: ${{ github.job }}-${{ matrix.php-version }}-${{ matrix.dependencies }}-coverage
           path: tests/.results/
 
   sonarcloud:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
-          name: build-8-coverage
+          name: build-8-highest-coverage
           path: tests/.results/
 
       - name: Fix Code Coverage Paths

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,15 @@
 
 Contributions are more than **welcome**.
 
-We accept contributions via Pull Requests on [Github](https://github.com/kununu/testing-bundle).
+We accept contributions via Pull Requests on [GitHub](https://github.com/kununu/testing-bundle).
 
 ## Pull Requests
 
 - **[kununu Coding Standards](https://github.com/kununu/kununu-scripts)** - The kununu coding standards are an extension of the [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md). Check out [kununu Coding Standards](https://github.com/kununu/kununu-scripts) for more details. In development mode the package [kununu-scripts](https://github.com/kununu/kununu-scripts) is already a dependency that expose commands that you can use to meet our standards.
 
-- **Add tests!** - to ensure a high quality code base, your code patch can't be accepted if it doesn't have tests.
+- **Add tests!** - to ensure a high quality code base, your code patch can't be accepted if it does not have tests.
 
-- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
+- **Document any change in behaviour** - Make sure the `CHANGELOG.md`, `README.md` and any other relevant documentation are kept up-to-date.
 
 - **Consider our release cycle** - Since we're using semantic versioning ([SemVer v2.0.0](http://semver.org/)). Changes to the API must be done with great consideration, and prevented if at all possible.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,16 +9,16 @@ Additionally, if you have a fix then please create a pull request and link it to
 
 ### Reporting a Vulnerability
 
-Jira is our entrypoint to report security vulnerabilities. Having this mind a KUNSECU user story (type Vulnerability) needs to be created. 
+Jira is our entrypoint to report security vulnerabilities. Having this in mind a KUNSECU user story (type Vulnerability) needs to be created. 
 
 #### How to fill the user story? 
 
-Follow this [documentation](https://confluence.xing.hh/pages/viewpage.action?pageId=381133070).
+Follow this [documentation](https://new-work.atlassian.net/wiki/spaces/kununu/pages/47846323/Vulnerability+Issue+Type+Jira).
 
 #### To which team do I assign the user story? 
 
-Follow the [component ownership matrix](https://confluence.xing.hh/display/kununu/Component+ownership+and+support) and assign it to the corresponding team.
+Follow the [domain ownership matrix](https://new-work.atlassian.net/wiki/spaces/kununu/pages/113148000/Domain+ownership+matrix) and assign it to the corresponding team.
 
 ## Reporting the update of dependencies
 
-This is the benefit of having Dependabot. It will open pull requests for security and version updates. For more information check the Github [documentation](https://docs.github.com/en/github/administering-a-repository/managing-pull-requests-for-dependency-updates).
+This is the benefit of having Dependabot. It will open pull requests for security and version updates. For more information check the GitHub [documentation](https://docs.github.com/en/github/administering-a-repository/managing-pull-requests-for-dependency-updates).

--- a/composer.json
+++ b/composer.json
@@ -2,12 +2,13 @@
   "name": "kununu/testing-bundle",
   "description": "Testing made easy by providing helper classes and fixtures loading",
   "type": "symfony-bundle",
+  "license": "MIT",
+  "minimum-stability": "stable",
   "keywords": [
     "tests",
     "symfony",
     "fixtures"
   ],
-  "license": "MIT",
   "authors": [
     {
       "name": "Hugo Gonçalves",


### PR DESCRIPTION
# Description

The objective of this PR is to update the components used in continuous integration GitHub actions

## Details
- Update continuous integration components:
  - `ubuntu-20.04` to `ubuntu-22.04`
  - `actions/checkout` to v4
  - `ramsey/composer-install` to v2
  - `actions/upload-artifact` to v4
  - `actions/download-artifact` to v4
- Update links and typos in documentation
