### PR TITLE
Support only PHP 8.3 

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,7 +56,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          coverage: xdebug
+          coverage: pcov
           extensions: ${{ matrix.extensions }}
 
       - name: Install Composer Dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,6 @@ jobs:
         elasticsearch-version:
           - 6.8.15
         dependencies:
-          - lowest
           - highest
 
     services:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 8.1
+          - 8.3
         mysql-version:
           - 5.7
         elasticsearch-version:
@@ -25,9 +25,6 @@ jobs:
         dependencies:
           - lowest
           - highest
-        exclude:
-          - php-version: 8.1
-            dependencies: lowest
 
     services:
       mysql:
@@ -79,7 +76,7 @@ jobs:
           DATABASE_SERVER_VERSION: ${{ matrix.mysql-version }}
 
       - name: Run PHPUnit
-        run: vendor/bin/phpunit
+        run: vendor/bin/phpunit --log-junit tests/.results/tests-junit.xml --coverage-clover tests/.results/tests-clover.xml
         env:
           DEF_DATABASE_URL: mysql://root:root@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/default_db
           PERSISTENCE_DATABASE_URL: mysql://root:root@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/persistence_db
@@ -91,6 +88,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.job }}-${{ matrix.php-version }}-${{ matrix.dependencies }}-coverage
+          include-hidden-files: true
           path: tests/.results/
 
   sonarcloud:
@@ -104,7 +102,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: build-8.1-highest-coverage
+          name: build-8.3-highest-coverage
           path: tests/.results/
 
       - name: Fix Code Coverage Paths
@@ -114,7 +112,7 @@ jobs:
           sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' tests-junit.xml
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarcloud-github-action@v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It also provides some utilities that makes testing easier, like a `RequestBuilde
 
 **Please be aware that this bundle should not be used in production mode!**
 
-```bash
+```shell
 composer require --dev kununu/testing-bundle
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     }
   ],
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.3",
     "symfony/framework-bundle": "^5.4|^6.4",
-    "kununu/data-fixtures": "^11.0",
+    "kununu/data-fixtures": "^12.0",
     "symfony/config": "^5.4|^6.4",
     "symfony/dependency-injection": "^5.4|^6.4",
     "symfony/http-kernel": "^5.4|^6.4"
@@ -36,8 +36,8 @@
     "doctrine/orm": "^3.0",
     "elasticsearch/elasticsearch": "^7.10",
     "kununu/scripts": ">=5.0",
-    "matthiasnoback/symfony-dependency-injection-test": "^5.1",
-    "phpunit/phpunit": "^10.5",
+    "matthiasnoback/symfony-dependency-injection-test": "^6.0",
+    "phpunit/phpunit": "^11.3",
     "psr/cache": "^1.0|^2.0",
     "symfony/browser-kit": "^6.4",
     "symfony/dotenv": "^6.4",
@@ -84,12 +84,12 @@
     "test": [
       "rm -rf tests/App/var/*",
       "tests/App/bin/setup_databases.sh test",
-      "phpunit --log-events-text phpunit.log --no-coverage --no-logging --no-progress --testsuite Full"
+      "phpunit --log-events-text phpunit.log --no-coverage --no-logging --no-progress --testsuite Unit,Integration"
     ],
     "test-coverage": [
       "rm -rf tests/App/var/*",
       "tests/App/bin/setup_databases.sh test",
-      "XDEBUG_MODE=coverage phpunit --log-events-text phpunit.log --no-progress --testsuite Full"
+      "XDEBUG_MODE=coverage phpunit --log-events-text phpunit.log --no-progress --testsuite Unit,Integration --log-junit tests/.results/tests-junit.xml --coverage-clover tests/.results/tests-clover.xml --coverage-html tests/.results/html"
     ]
   },
   "scripts-descriptions": {

--- a/docs/FixturesTypes/cache-pool-fixtures.md
+++ b/docs/FixturesTypes/cache-pool-fixtures.md
@@ -16,7 +16,7 @@ framework:
 
 ## How to load Cache Pool Fixtures?
 
-In your tests you can extend the classes [FixturesAwareTestCase](/src/Test/FixturesAwareTestCase.php) or [WebTestCase](/src/Test/WebTestCase.php) which expose the following method:
+In your tests you can extend the classes [FixturesAwareTestCase](../../src/Test/FixturesAwareTestCase.php) or [WebTestCase](../../src/Test/WebTestCase.php) which expose the following method:
 
 ```php
 protected function loadCachePoolFixtures(string $cachePoolServiceId, OptionsInterface $options, string ...$classNames): void
@@ -24,9 +24,9 @@ protected function loadCachePoolFixtures(string $cachePoolServiceId, OptionsInte
 
 - `$cachePoolServiceId` - Name of your pool as configured in the config above
 - `$options` - [Options](options.md) for the fixtures load process
-- `...$classNames` - Classes names of fixtures to load
+- `$classNames` - Classes names of fixtures to load
 
-**Example of loading fixtures in a Integration Test**
+**Example of loading fixtures in an Integration Test**
 
 ```php
 use Kununu\TestingBundle\Test\FixturesAwareTestCase;
@@ -59,7 +59,7 @@ final class IntegrationTest extends FixturesAwareTestCase
 }
 ```
 
-You can also disable the creation of orchestrators services for cache pools if you don't want to use fixtures on cache pools (see [configuration](#Configuration)).
+You can also disable the creation of orchestrators services for cache pools if you don't want to use fixtures on cache pools (see [configuration](#configuration)).
 
 -----------------------
 
@@ -67,7 +67,7 @@ You can also disable the creation of orchestrators services for cache pools if y
 
 This bundle can automatically create a Symfony Command to load default fixtures for any cache pool. This can be useful for example when you want to have default fixtures for a cache pool that are loaded when your service spins up. At kununu we make use of this and when one of our services starts, we call a script, *run_startup.sh*, that on the *dev* and *test* environments calls this commands so that each cache pool starts with a set of a default fixtures.
 
-```bash
+```shell
 php bin/console kununu_testing:load_fixtures:cache_pools:MY_CACHE_ID [--append]
 ```
 
@@ -89,7 +89,7 @@ kununu_testing:
 
 The fixtures can be loaded for a cache pool by running:
 
-```bash
+```shell
 php bin/console kununu_testing:load_fixtures:cache_pools:app.cache.first --append
 ```
 

--- a/docs/FixturesTypes/doctrine-dbal-connection-fixtures.md
+++ b/docs/FixturesTypes/doctrine-dbal-connection-fixtures.md
@@ -17,7 +17,7 @@ doctrine:
 
 ## How to load Doctrine Connection Fixtures?
 
-In your tests you can extend the classes [FixturesAwareTestCase](/src/Test/FixturesAwareTestCase.php) or [WebTestCase](/src/Test/WebTestCase.php) which expose the following method:
+In your tests you can extend the classes [FixturesAwareTestCase](../../src/Test/FixturesAwareTestCase.php) or [WebTestCase](../../src/Test/WebTestCase.php) which expose the following method:
 
 ```php
 protected function loadDbFixtures(string $connectionName, DbOptionsInterface $options, string ...$classNames)
@@ -25,9 +25,9 @@ protected function loadDbFixtures(string $connectionName, DbOptionsInterface $op
 
 - `$connectionName` - Name of your connection
 - `$options` - [Options](options.md) for the fixtures load process
-- `...$classNames` - Classes names of fixtures to load
+- `$classNames` - Classes names of fixtures to load
 
-**Example of loading fixtures in a Integration Test**
+**Example of loading fixtures in an Integration Test**
 
 ```php
 use Kununu\TestingBundle\Test\FixturesAwareTestCase;
@@ -98,13 +98,13 @@ final class IntegrationTest extends FixturesAwareTestCase
 
 This bundle can automatically create a Symfony Command to load default fixtures for any connection. This can be useful for example when you want to have default fixtures for a database that are loaded when your service spins up. At kununu we make use of this and when one of our services starts, we call a script, *run_startup.sh*, that on the *dev* and *test* environments calls this commands so that each database starts with a set of a default fixtures.
 
-```bash
+```shell
 php bin/console kununu_testing:load_fixtures:connections:CONNECTION_NAME [--append]
 ```
 
 Or for non-transactional fixtures:
 
-```bash
+```shell
 php bin/console kununu_testing:load_fixtures:non_transactional_connections:CONNECTION_NAME [--append]
 ```
 
@@ -130,13 +130,13 @@ kununu_testing:
 
 The fixtures can be loaded for a Connection by running:
 
-```bash
+```shell
 php bin/console kununu_testing:load_fixtures:connections:default --append
 ```
 
 Or for non-transactional fixtures:
 
-```bash
+```shell
 php bin/console kununu_testing:load_fixtures:non_transactional_connections:default --append
 ```
 

--- a/docs/FixturesTypes/elasticsearch.md
+++ b/docs/FixturesTypes/elasticsearch.md
@@ -16,7 +16,7 @@ kununu_testing:
       index_name: 'my_index_name'
 ```
 
-In your tests you can extend the classes [FixturesAwareTestCase](/src/Test/FixturesAwareTestCase.php) or [WebTestCase](/src/Test/WebTestCase.php) which expose the following method:
+In your tests you can extend the classes [FixturesAwareTestCase](../../src/Test/FixturesAwareTestCase.php) or [WebTestCase](../../src/Test/WebTestCase.php) which expose the following method:
 
 ```php
 protected function loadElasticsearchFixtures(string $alias, OptionsInterface $options, string ...$classNames): void
@@ -25,9 +25,9 @@ protected function loadElasticsearchFixtures(string $alias, OptionsInterface $op
 - `$alias` - Alias defined above
 - `$classNames` - Array with classes names of fixtures to load
 - `$options` - [Options](options.md) for the fixtures load process
-- `...$classNames` - Classes names of fixtures to load
+- `$classNames` - Classes names of fixtures to load
 
-**Example of loading fixtures in a Integration Test**
+**Example of loading fixtures in an Integration Test**
 
 ```php
 use Kununu\TestingBundle\Test\FixturesAwareTestCase;
@@ -66,11 +66,11 @@ final class IntegrationTest extends FixturesAwareTestCase
 
 This bundle can automatically create a Symfony Command to load default fixtures for any configured Elasticsearch Index. This can be useful for example when you want to have default fixtures for a Elasticsearch Index that are loaded when your service spins up. At kununu we make use of this and when one of our services starts, we call a script, *run_startup.sh*, that on the *dev* and *test* environments calls this commands so that each Elasticsearch Index starts with a set of a default fixtures.
 
-```bash
+```shell
 php bin/console kununu_testing:load_fixtures:elastic_search:MY_INDEX_ALIAS [--append]
 ```
 
-### 1. Enable Symfony Command for a Elasticsearch Index
+### 1. Enable Symfony Command for an Elasticsearch Index
 
 By default, Symfony Commands are not created for any Elasticsearch Index. If you want to enable the creation of a Symfony Command for a specific Index you will need to enable it the configuration of the bundle by setting the option `load_command_fixtures_classes_namespace` where you specify the classes names of the fixtures that the command should run.
 
@@ -87,7 +87,7 @@ kununu_testing:
 
 The fixtures can be loaded for an Elasticsearch Index by running:
 
-```bash
+```shell
 php bin/console kununu_testing:load_fixtures:elastic_search:my_index_alias --append
 ```
 

--- a/docs/FixturesTypes/options.md
+++ b/docs/FixturesTypes/options.md
@@ -1,10 +1,10 @@
 # FixturesAwareTestCase Options
 
-The methods to load fixtures on [FixturesAwareTestCase](/src/Test/FixturesAwareTestCase.php) need to receive a parameter `$options`.
+The methods to load fixtures on [FixturesAwareTestCase](../../src/Test/FixturesAwareTestCase.php) need to receive a parameter `$options`.
 
 ## OptionsInterface
 
-That object must implement the interface [OptionsInterface](/src/Test/Options/OptionsInterface.php) which defines the following methods:
+That object must implement the interface [OptionsInterface](../../src/Test/Options/OptionsInterface.php) which defines the following methods:
 
 ```php
 public function append(): bool;
@@ -22,7 +22,7 @@ If this method returns `true` then it will clear any previous loaded fixtures cl
 
 ## Options
 
-The class [Options](/src/Test/Options/Options.php) is provided, and it implements the `OptionsInterface` and also provides a builder pattern.
+The class [Options](../../src/Test/Options/Options.php) is provided, and it implements the `OptionsInterface` and also provides a builder pattern.
 
 ```php
 use Kununu\TestingBundle\Test\Options\Options;
@@ -55,7 +55,7 @@ $options = Options::create()->withoutClear()->withAppend();
 
 To load fixtures with database connections (`loadDbFixtures`) it is required to pass a more specialized instance of options.
 
-That object must implement the interface [DbOptionsInterface](/src/Test/Options/DbOptionsInterface.php) which is an extension of `OptionsInterface` (thus having all the same methods) and adds the following method:
+That object must implement the interface [DbOptionsInterface](../../src/Test/Options/DbOptionsInterface.php) which is an extension of `OptionsInterface` (thus having all the same methods) and adds the following method:
 
 ```php
 public function transactional(): bool;
@@ -67,7 +67,7 @@ If this method returns `true` then it will use a transactional executor, otherwi
 
 ## DbOptions
 
-The class [DbOptions](/src/Test/Options/DbOptions.php) is provided, and it implements the `DbOptionsInterface` and also provides a builder pattern.
+The class [DbOptions](../../src/Test/Options/DbOptions.php) is provided, and it implements the `DbOptionsInterface` and also provides a builder pattern.
 
 It extends the `Options` class so all the methods available there are still in this class.
 

--- a/docs/FixturesTypes/symfony-http-client.md
+++ b/docs/FixturesTypes/symfony-http-client.md
@@ -8,7 +8,7 @@ In the rest of the documentation we will assume that you are using the [Symfony 
 
 ## How to load Symfony Http Client Fixtures?
 
-In your tests you can extend the classes [FixturesAwareTestCase](/src/Test/FixturesAwareTestCase.php) or [WebTestCase](/src/Test/WebTestCase.php) which expose the following method:
+In your tests you can extend the classes [FixturesAwareTestCase](../../src/Test/FixturesAwareTestCase.php) or [WebTestCase](../../src/Test/WebTestCase.php) which expose the following method:
 
 ```php
 protected function loadHttpClientFixtures(string $httpClientServiceId, OptionsInterface $options, string ...$classNames): void
@@ -16,7 +16,7 @@ protected function loadHttpClientFixtures(string $httpClientServiceId, OptionsIn
 
 - `$httpClientServiceId` - Name of your Symfony Http Client service
 - `$options` - [Options](options.md) for the fixtures load process
-- `...$classNames` - Classes names of fixtures to load
+- `$classNames` - Classes names of fixtures to load
 
 **Example of loading fixtures in an Integration Test**
 
@@ -97,3 +97,28 @@ Also be mindful that **if you inject the same client on several services** you m
 Example: you are testing service A which uses component B. Component B is also injected with the same Http client but is calling totally different endpoints.
 
 To solve those cases create dedicated Http clients services for the service you are testing.
+
+### Common Problems and Solutions
+
+#### The mocked Http Client is not being used
+
+- Try to create an alias of the Symfony interface to your client in your *test* environment configuration:
+
+```yaml
+services:
+  http_client:
+    class: Kununu\DataFixtures\Tools\HttpClient
+    public: true
+
+  Symfony\Contracts\HttpClient\HttpClientInterface: '@http_client'
+```
+
+- If the mock Http client is still not loaded make sure to add to your *test* environment `framework.yaml` file:
+
+```yaml
+framework:
+  http_client:
+    enabled: false
+```
+
+To disable Symfony Framework bundle creating its own Http clients.

--- a/docs/SchemaCopier/schema-copier.md
+++ b/docs/SchemaCopier/schema-copier.md
@@ -14,7 +14,7 @@ This bundle will provide you with a command that can fetch the schema for that e
 
 This bundle will automatically create a Symfony Command allow copying databases schemas (if you have at least a Doctrine connection configured).
 
-```bash
+```shell
 php bin/console kununu_testing:connections:schema:copy --from SOURCE --to DESTINATION
 ```
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://phpunit.readthedocs.io/en/10.5/ -->
+<!-- https://docs.phpunit.de/en/11.3/ -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="tests/bootstrap.php"
          colors="true" beStrictAboutChangesToGlobalState="true" cacheDirectory=".phpunit.cache" testdox="true">
-  <coverage>
-    <report>
-      <clover outputFile="tests/.results/tests-clover.xml"/>
-      <html outputDirectory="tests/.results/html/"/>
-    </report>
-  </coverage>
   <php>
     <ini name="error_reporting" value="-1"/>
     <server name="APP_ENV" value="test" force="true"/>
@@ -16,9 +10,6 @@
     <server name="KERNEL_CLASS" value="Kununu\TestingBundle\Tests\App\Kernel"/>
   </php>
   <testsuites>
-    <testsuite name="Full">
-      <directory>tests</directory>
-    </testsuite>
     <testsuite name="Integration">
       <directory>tests/Integration</directory>
     </testsuite>
@@ -26,9 +17,6 @@
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <logging>
-    <junit outputFile="tests/.results/tests-junit.xml"/>
-  </logging>
   <source>
     <include>
       <directory>src</directory>

--- a/src/Command/CopyConnectionSchemaCommand.php
+++ b/src/Command/CopyConnectionSchemaCommand.php
@@ -15,14 +15,14 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class CopyConnectionSchemaCommand extends Command
 {
-    private const OPTION_FROM = 'from';
-    private const OPTION_FROM_SHORT = 'f';
-    private const OPTION_TO = 'to';
-    private const OPTION_TO_SHORT = 't';
+    private const string OPTION_FROM = 'from';
+    private const string OPTION_FROM_SHORT = 'f';
+    private const string OPTION_TO = 'to';
+    private const string OPTION_TO_SHORT = 't';
 
     public function __construct(
         private readonly SchemaCopyInterface $schemaCopy,
-        private readonly ManagerRegistry $registry
+        private readonly ManagerRegistry $registry,
     ) {
         parent::__construct('kununu_testing:connections:schema:copy');
     }
@@ -75,7 +75,7 @@ final class CopyConnectionSchemaCommand extends Command
         ?Connection $connection,
         string $arg,
         string $connectionName,
-        OutputInterface $output
+        OutputInterface $output,
     ): bool {
         $connectionName = trim($connectionName);
 
@@ -100,7 +100,7 @@ final class CopyConnectionSchemaCommand extends Command
         return true;
     }
 
-    private function getConnection(string $connectionName): Connection|null
+    private function getConnection(string $connectionName): ?Connection
     {
         /* @var Connection|null $connection */
         try {

--- a/src/Command/LoadFixturesCommand.php
+++ b/src/Command/LoadFixturesCommand.php
@@ -12,12 +12,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 abstract class LoadFixturesCommand extends Command
 {
-    protected const OPTION_APPEND = 'append';
+    protected const string OPTION_APPEND = 'append';
 
     public function __construct(
         private readonly string $alias,
         private readonly OrchestratorInterface $orchestrator,
-        private readonly array $fixturesClassNames
+        private readonly array $fixturesClassNames,
     ) {
         parent::__construct(sprintf('kununu_testing:load_fixtures:%s:%s', static::getFixtureType(), $alias));
     }

--- a/src/DependencyInjection/Compiler/AbstractConnectionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AbstractConnectionCompilerPass.php
@@ -13,9 +13,9 @@ abstract class AbstractConnectionCompilerPass extends AbstractCompilerPass
 {
     use LoadFixturesCommandsTrait;
 
-    private const EXCLUDED_TABLES_CONFIG = 'excluded_tables';
-    private const LOAD_COMMAND_FIXTURES_CLASSES_NAMESPACE_CONFIG = 'load_command_fixtures_classes_namespace';
-    private const ORCHESTRATOR_SERVICE_PREFIX = 'kununu_testing.orchestrator.%s';
+    private const string EXCLUDED_TABLES_CONFIG = 'excluded_tables';
+    private const string LOAD_COMMAND_FIXTURES_CLASSES_NAMESPACE_CONFIG = 'load_command_fixtures_classes_namespace';
+    private const string ORCHESTRATOR_SERVICE_PREFIX = 'kununu_testing.orchestrator.%s';
 
     private readonly string $orchestratorServicePrefix;
 
@@ -53,7 +53,7 @@ abstract class AbstractConnectionCompilerPass extends AbstractCompilerPass
         ContainerBuilder $container,
         string $connId,
         string $connName,
-        array $connConfig
+        array $connConfig,
     ): void {
         $orchestratorId = $this->buildConnectionOrchestrator($container, $connId, $connName, $connConfig);
 
@@ -79,7 +79,7 @@ abstract class AbstractConnectionCompilerPass extends AbstractCompilerPass
         ContainerBuilder $container,
         string $id,
         string $connName,
-        array $connConfig
+        array $connConfig,
     ): string {
         // Purger Definition for the Connection with provided $id
         $purgerId = sprintf('%s.%s.purger', $this->orchestratorServicePrefix, $connName);

--- a/src/DependencyInjection/Compiler/CachePoolCompilerPass.php
+++ b/src/DependencyInjection/Compiler/CachePoolCompilerPass.php
@@ -16,8 +16,8 @@ final class CachePoolCompilerPass extends AbstractCompilerPass
 {
     use LoadFixturesCommandsTrait;
 
-    private const SERVICE_PREFIX = 'kununu_testing.orchestrator.cache_pools';
-    private const CACHE_POOL_TAG = 'cache.pool';
+    private const string SERVICE_PREFIX = 'kununu_testing.orchestrator.cache_pools';
+    private const string CACHE_POOL_TAG = 'cache.pool';
 
     private array $config = [];
 

--- a/src/DependencyInjection/Compiler/ElasticsearchCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ElasticsearchCompilerPass.php
@@ -17,8 +17,8 @@ final class ElasticsearchCompilerPass implements CompilerPassInterface
 {
     use LoadFixturesCommandsTrait;
 
-    private const SERVICE_PREFIX = 'kununu_testing.orchestrator.elastic_search';
-    private const LOAD_COMMAND_FIXTURES_CLASSES_NAMESPACE_CONFIG = 'load_command_fixtures_classes_namespace';
+    private const string SERVICE_PREFIX = 'kununu_testing.orchestrator.elastic_search';
+    private const string LOAD_COMMAND_FIXTURES_CLASSES_NAMESPACE_CONFIG = 'load_command_fixtures_classes_namespace';
 
     public function process(ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/Compiler/HttpClientCompilerPass.php
+++ b/src/DependencyInjection/Compiler/HttpClientCompilerPass.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class HttpClientCompilerPass extends AbstractCompilerPass
 {
-    private const SERVICE_PREFIX = 'kununu_testing.orchestrator.http_client';
+    private const string SERVICE_PREFIX = 'kununu_testing.orchestrator.http_client';
 
     private array $config = [];
 

--- a/src/DependencyInjection/KununuTestingExtension.php
+++ b/src/DependencyInjection/KununuTestingExtension.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 final class KununuTestingExtension extends Extension implements ExtensionConfigurationInterface
 {
-    public const ALIAS = 'kununu_testing';
+    public const string ALIAS = 'kununu_testing';
 
     private array $config = [];
 

--- a/src/Service/Orchestrator.php
+++ b/src/Service/Orchestrator.php
@@ -6,9 +6,9 @@ namespace Kununu\TestingBundle\Service;
 use Kununu\DataFixtures\Executor\ExecutorInterface;
 use Kununu\DataFixtures\Loader\LoaderInterface;
 
-final class Orchestrator implements OrchestratorInterface
+final readonly class Orchestrator implements OrchestratorInterface
 {
-    public function __construct(private readonly ExecutorInterface $executor, private readonly LoaderInterface $loader)
+    public function __construct(private ExecutorInterface $executor, private LoaderInterface $loader)
     {
     }
 

--- a/src/Service/SchemaCopy/Adapter/AbstractAdapter.php
+++ b/src/Service/SchemaCopy/Adapter/AbstractAdapter.php
@@ -8,7 +8,7 @@ use Kununu\TestingBundle\Service\SchemaCopy\SchemaCopyAdapterInterface;
 
 abstract class AbstractAdapter implements SchemaCopyAdapterInterface
 {
-    protected const TYPE = '';
+    protected const string TYPE = '';
 
     public function __construct(protected readonly Connection $connection)
     {

--- a/src/Service/SchemaCopy/Adapter/MySqlAdapter.php
+++ b/src/Service/SchemaCopy/Adapter/MySqlAdapter.php
@@ -5,7 +5,7 @@ namespace Kununu\TestingBundle\Service\SchemaCopy\Adapter;
 
 final class MySqlAdapter extends AbstractAdapter
 {
-    protected const TYPE = 'MySql';
+    protected const string TYPE = 'MySql';
 
     public function disableConstraints(): void
     {

--- a/src/Service/SchemaCopy/Copier/SchemaCopier.php
+++ b/src/Service/SchemaCopy/Copier/SchemaCopier.php
@@ -8,9 +8,9 @@ use Kununu\TestingBundle\Service\SchemaCopy\Exception\IncompatibleAdaptersExcept
 use Kununu\TestingBundle\Service\SchemaCopy\SchemaCopyAdapterFactoryInterface;
 use Kununu\TestingBundle\Service\SchemaCopy\SchemaCopyInterface;
 
-final class SchemaCopier implements SchemaCopyInterface
+final readonly class SchemaCopier implements SchemaCopyInterface
 {
-    public function __construct(private readonly SchemaCopyAdapterFactoryInterface $adapterFactory)
+    public function __construct(private SchemaCopyAdapterFactoryInterface $adapterFactory)
     {
     }
 

--- a/src/Test/AbstractTestCase.php
+++ b/src/Test/AbstractTestCase.php
@@ -3,9 +3,10 @@ declare(strict_types=1);
 
 namespace Kununu\TestingBundle\Test;
 
-use Psr\Container\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use UnitEnum;
 
 abstract class AbstractTestCase extends WebTestCase
 {
@@ -18,6 +19,16 @@ abstract class AbstractTestCase extends WebTestCase
         }
 
         return static::getContainer();
+    }
+
+    final protected function getServiceFromContainer(string $service): ?object
+    {
+        return $this->getFixturesContainer()->get($service);
+    }
+
+    final protected function getParameterFromContainer(string $name): UnitEnum|float|array|bool|int|string|null
+    {
+        return $this->getFixturesContainer()->getParameter($name);
     }
 
     final protected function getKernelBrowser(): KernelBrowser

--- a/src/Test/FixturesAwareTestCase.php
+++ b/src/Test/FixturesAwareTestCase.php
@@ -9,16 +9,16 @@ use Kununu\TestingBundle\Test\Options\OptionsInterface;
 
 abstract class FixturesAwareTestCase extends AbstractTestCase
 {
-    private const KEY_CONNECTIONS = 'connections';
-    private const KEY_NON_TRANSACTIONAL_CONNECTIONS = 'non_transactional_connections';
-    private const KEY_CACHE_POOLS = 'cache_pools';
-    private const KEY_ELASTICSEARCH = 'elastic_search';
-    private const KEY_HTTP_CLIENT = 'http_client';
+    private const string KEY_CONNECTIONS = 'connections';
+    private const string KEY_NON_TRANSACTIONAL_CONNECTIONS = 'non_transactional_connections';
+    private const string KEY_CACHE_POOLS = 'cache_pools';
+    private const string KEY_ELASTICSEARCH = 'elastic_search';
+    private const string KEY_HTTP_CLIENT = 'http_client';
 
     final protected function loadDbFixtures(
         string $connectionName,
         DbOptionsInterface $options,
-        string ...$classNames
+        string ...$classNames,
     ): void {
         $this
             ->getOrchestrator(
@@ -31,7 +31,7 @@ abstract class FixturesAwareTestCase extends AbstractTestCase
     final protected function loadCachePoolFixtures(
         string $cachePoolServiceId,
         OptionsInterface $options,
-        string ...$classNames
+        string ...$classNames,
     ): void {
         $this
             ->getOrchestrator(self::KEY_CACHE_POOLS, $cachePoolServiceId)
@@ -41,7 +41,7 @@ abstract class FixturesAwareTestCase extends AbstractTestCase
     final protected function loadElasticsearchFixtures(
         string $alias,
         OptionsInterface $options,
-        string ...$classNames
+        string ...$classNames,
     ): void {
         $this
             ->getOrchestrator(self::KEY_ELASTICSEARCH, $alias)
@@ -51,7 +51,7 @@ abstract class FixturesAwareTestCase extends AbstractTestCase
     final protected function loadHttpClientFixtures(
         string $httpClientServiceId,
         OptionsInterface $options,
-        string ...$classNames
+        string ...$classNames,
     ): void {
         $this
             ->getOrchestrator(self::KEY_HTTP_CLIENT, $httpClientServiceId)
@@ -61,7 +61,7 @@ abstract class FixturesAwareTestCase extends AbstractTestCase
     final protected function registerInitializableFixtureForDb(
         string $connectionName,
         string $className,
-        mixed ...$args
+        mixed ...$args,
     ): void {
         $this
             ->getOrchestrator(self::KEY_CONNECTIONS, $connectionName)
@@ -71,7 +71,7 @@ abstract class FixturesAwareTestCase extends AbstractTestCase
     final protected function registerInitializableFixtureForNonTransactionalDb(
         string $connectionName,
         string $className,
-        mixed ...$args
+        mixed ...$args,
     ): void {
         $this
             ->getOrchestrator(self::KEY_NON_TRANSACTIONAL_CONNECTIONS, $connectionName)
@@ -81,7 +81,7 @@ abstract class FixturesAwareTestCase extends AbstractTestCase
     final protected function registerInitializableFixtureForCachePool(
         string $cachePoolServiceId,
         string $className,
-        mixed ...$args
+        mixed ...$args,
     ): void {
         $this
             ->getOrchestrator(self::KEY_CACHE_POOLS, $cachePoolServiceId)
@@ -91,7 +91,7 @@ abstract class FixturesAwareTestCase extends AbstractTestCase
     final protected function registerInitializableFixtureForElasticsearch(
         string $alias,
         string $className,
-        mixed ...$args
+        mixed ...$args,
     ): void {
         $this
             ->getOrchestrator(self::KEY_ELASTICSEARCH, $alias)
@@ -101,7 +101,7 @@ abstract class FixturesAwareTestCase extends AbstractTestCase
     final protected function registerInitializableFixtureForHttpClient(
         string $httpClientServiceId,
         string $className,
-        mixed ...$args
+        mixed ...$args,
     ): void {
         $this
             ->getOrchestrator(self::KEY_HTTP_CLIENT, $httpClientServiceId)
@@ -168,6 +168,9 @@ abstract class FixturesAwareTestCase extends AbstractTestCase
 
     private function getOrchestrator(string $type, string $key): Orchestrator
     {
-        return $this->getFixturesContainer()->get(sprintf('kununu_testing.orchestrator.%s.%s', $type, $key));
+        $orchestrator = $this->getServiceFromContainer(sprintf('kununu_testing.orchestrator.%s.%s', $type, $key));
+        assert($orchestrator instanceof Orchestrator);
+
+        return $orchestrator;
     }
 }

--- a/src/Test/FixturesContainerGetterTrait.php
+++ b/src/Test/FixturesContainerGetterTrait.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\TestingBundle\Test;
+
+use Doctrine\DBAL\Connection;
+use Elasticsearch\Client;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+trait FixturesContainerGetterTrait
+{
+    protected function getConnection(string $connectionId = 'doctrine.dbal.default_connection'): Connection
+    {
+        $connection = $this->getServiceFromContainer($connectionId);
+        assert($connection instanceof Connection);
+
+        return $connection;
+    }
+
+    protected function getCachePool(string $cachePoolId): CacheItemPoolInterface
+    {
+        $cachePool = $this->getServiceFromContainer($cachePoolId);
+        assert($cachePool instanceof CacheItemPoolInterface);
+
+        return $cachePool;
+    }
+
+    protected function getElasticsearchClient(string $clientId = Client::class): Client
+    {
+        $client = $this->getServiceFromContainer($clientId);
+        assert($client instanceof Client);
+
+        return $client;
+    }
+
+    protected function getHttpClient(string $httpClientId = 'http_client'): HttpClientInterface
+    {
+        $client = $this->getServiceFromContainer($httpClientId);
+        assert($client instanceof HttpClientInterface);
+
+        return $client;
+    }
+}

--- a/src/Test/Options/AbstractOptions.php
+++ b/src/Test/Options/AbstractOptions.php
@@ -5,10 +5,10 @@ namespace Kununu\TestingBundle\Test\Options;
 
 abstract class AbstractOptions
 {
-    protected const OPTIONS = [];
+    protected const array OPTIONS = [];
 
-    private const PREFIX_WITH = 'with';
-    private const PREFIX_WITHOUT = 'without';
+    private const string PREFIX_WITH = 'with';
+    private const string PREFIX_WITHOUT = 'without';
 
     private array $options = [];
 

--- a/src/Test/Options/DbOptions.php
+++ b/src/Test/Options/DbOptions.php
@@ -13,7 +13,7 @@ namespace Kununu\TestingBundle\Test\Options;
  */
 class DbOptions extends Options implements DbOptionsInterface
 {
-    protected const OPTIONS = [
+    protected const array OPTIONS = [
         'transactional' => true,
     ];
 

--- a/src/Test/Options/Options.php
+++ b/src/Test/Options/Options.php
@@ -11,7 +11,7 @@ namespace Kununu\TestingBundle\Test\Options;
  */
 class Options extends AbstractOptions implements OptionsInterface
 {
-    protected const OPTIONS = [
+    protected const array OPTIONS = [
         'append' => false,
         'clear'  => true,
     ];

--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -14,9 +14,7 @@ abstract class WebTestCase extends FixturesAwareTestCase
         string $httpClientName = 'http_client',
         ?Options $options = null,
     ): Response {
-        $httpClientFixtures = interface_exists(HttpClientInterface::class)
-            ? $this->getHttpClientFixtures($httpClientName)
-            : null;
+        $httpClientFixtures = $this->getPreviousHttpClientFixtures($httpClientName);
 
         $this->shutdown();
 
@@ -41,5 +39,11 @@ abstract class WebTestCase extends FixturesAwareTestCase
         }
 
         return $response;
+    }
+
+    /** @codeCoverageIgnore */
+    private function getPreviousHttpClientFixtures(string $httpClientName): ?array
+    {
+        return interface_exists(HttpClientInterface::class) ? $this->getHttpClientFixtures($httpClientName) : null;
     }
 }

--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -9,8 +9,11 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 abstract class WebTestCase extends FixturesAwareTestCase
 {
-    final protected function doRequest(RequestBuilder $builder, string $httpClientName = 'http_client', ?Options $options = null): Response
-    {
+    final protected function doRequest(
+        RequestBuilder $builder,
+        string $httpClientName = 'http_client',
+        ?Options $options = null,
+    ): Response {
         $httpClientFixtures = interface_exists(HttpClientInterface::class)
             ? $this->getHttpClientFixtures($httpClientName)
             : null;

--- a/tests/App/Fixtures/CachePool/CachePoolFixture2.php
+++ b/tests/App/Fixtures/CachePool/CachePoolFixture2.php
@@ -6,7 +6,7 @@ namespace Kununu\TestingBundle\Tests\App\Fixtures\CachePool;
 use Kununu\DataFixtures\Adapter\CachePoolFixtureInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
-final class CachePoolFixture2 implements CachePoolFixtureInterface
+final readonly class CachePoolFixture2 implements CachePoolFixtureInterface
 {
     public function load(CacheItemPoolInterface $cachePool): void
     {

--- a/tests/App/Fixtures/CachePool/CachePoolFixture3.php
+++ b/tests/App/Fixtures/CachePool/CachePoolFixture3.php
@@ -6,7 +6,7 @@ namespace Kununu\TestingBundle\Tests\App\Fixtures\CachePool;
 use Kununu\DataFixtures\Adapter\CachePoolFixtureInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
-final class CachePoolFixture3 implements CachePoolFixtureInterface
+final readonly class CachePoolFixture3 implements CachePoolFixtureInterface
 {
     public function load(CacheItemPoolInterface $cachePool): void
     {

--- a/tests/App/Fixtures/Connection/ConnectionFixture2.php
+++ b/tests/App/Fixtures/Connection/ConnectionFixture2.php
@@ -6,7 +6,7 @@ namespace Kununu\TestingBundle\Tests\App\Fixtures\Connection;
 use Doctrine\DBAL\Connection;
 use Kununu\DataFixtures\Adapter\ConnectionFixtureInterface;
 
-final class ConnectionFixture2 implements ConnectionFixtureInterface
+final readonly class ConnectionFixture2 implements ConnectionFixtureInterface
 {
     public function load(Connection $connection): void
     {

--- a/tests/App/Fixtures/Connection/ConnectionFixture3.php
+++ b/tests/App/Fixtures/Connection/ConnectionFixture3.php
@@ -6,7 +6,7 @@ namespace Kununu\TestingBundle\Tests\App\Fixtures\Connection;
 use Doctrine\DBAL\Connection;
 use Kununu\DataFixtures\Adapter\ConnectionFixtureInterface;
 
-final class ConnectionFixture3 implements ConnectionFixtureInterface
+final readonly class ConnectionFixture3 implements ConnectionFixtureInterface
 {
     public function load(Connection $connection): void
     {

--- a/tests/App/Fixtures/Connection/ConnectionFixture4.php
+++ b/tests/App/Fixtures/Connection/ConnectionFixture4.php
@@ -6,7 +6,7 @@ namespace Kununu\TestingBundle\Tests\App\Fixtures\Connection;
 use Doctrine\DBAL\Connection;
 use Kununu\DataFixtures\Adapter\ConnectionFixtureInterface;
 
-final class ConnectionFixture4 implements ConnectionFixtureInterface
+final readonly class ConnectionFixture4 implements ConnectionFixtureInterface
 {
     public function load(Connection $connection): void
     {

--- a/tests/App/Fixtures/Connection/ConnectionFixture5.php
+++ b/tests/App/Fixtures/Connection/ConnectionFixture5.php
@@ -6,7 +6,7 @@ namespace Kununu\TestingBundle\Tests\App\Fixtures\Connection;
 use Doctrine\DBAL\Connection;
 use Kununu\DataFixtures\Adapter\ConnectionFixtureInterface;
 
-final class ConnectionFixture5 implements ConnectionFixtureInterface
+final readonly class ConnectionFixture5 implements ConnectionFixtureInterface
 {
     public function load(Connection $connection): void
     {

--- a/tests/App/Fixtures/Connection/ConnectionFixture6.php
+++ b/tests/App/Fixtures/Connection/ConnectionFixture6.php
@@ -6,7 +6,7 @@ namespace Kununu\TestingBundle\Tests\App\Fixtures\Connection;
 use Doctrine\DBAL\Connection;
 use Kununu\DataFixtures\Adapter\ConnectionFixtureInterface;
 
-final class ConnectionFixture6 implements ConnectionFixtureInterface
+final readonly class ConnectionFixture6 implements ConnectionFixtureInterface
 {
     public function load(Connection $connection): void
     {

--- a/tests/App/Fixtures/Elasticsearch/ElasticsearchFixture2.php
+++ b/tests/App/Fixtures/Elasticsearch/ElasticsearchFixture2.php
@@ -6,7 +6,7 @@ namespace Kununu\TestingBundle\Tests\App\Fixtures\Elasticsearch;
 use Elasticsearch\Client;
 use Kununu\DataFixtures\Adapter\ElasticsearchFixtureInterface;
 
-final class ElasticsearchFixture2 implements ElasticsearchFixtureInterface
+final readonly class ElasticsearchFixture2 implements ElasticsearchFixtureInterface
 {
     public function load(Client $elasticSearch, string $indexName, bool $throwOnFail = true): void
     {

--- a/tests/App/Migrations/Version20210428225538.php
+++ b/tests/App/Migrations/Version20210428225538.php
@@ -59,4 +59,9 @@ SQL
         // I don't care!
         $this->throwIrreversibleMigrationException();
     }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
 }

--- a/tests/App/config/packages/parameters.yaml
+++ b/tests/App/config/packages/parameters.yaml
@@ -4,3 +4,4 @@ parameters:
   def_database_url: '%env(resolve:DEF_DATABASE_URL)%'
   persistence_database_url: '%env(resolve:PERSISTENCE_DATABASE_URL)%'
   monolithic_database_url: '%env(resolve:MONOLITHIC_DATABASE_URL)%'
+  dummy_param: 'i am a parameter'

--- a/tests/Integration/Command/AbstractCommandTestCase.php
+++ b/tests/Integration/Command/AbstractCommandTestCase.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 namespace Kununu\TestingBundle\Tests\Integration\Command;
 
 use Kununu\TestingBundle\Test\FixturesAwareTestCase;
+use Kununu\TestingBundle\Test\FixturesContainerGetterTrait;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Tester\CommandTester;
 
 abstract class AbstractCommandTestCase extends FixturesAwareTestCase
 {
+    use FixturesContainerGetterTrait;
+
     protected Application $application;
     protected CommandTester $commandTester;
 
@@ -19,7 +22,7 @@ abstract class AbstractCommandTestCase extends FixturesAwareTestCase
 
         $command = $this->application->find($existingCommandAlias);
 
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             $this->getCommandClass(),
             $command,
             sprintf('Asserted that console command "%s" exists', $existingCommandAlias)
@@ -28,9 +31,9 @@ abstract class AbstractCommandTestCase extends FixturesAwareTestCase
         foreach ($this->getNonExistingCommandAliases() as $nonExistingCommandAlias) {
             try {
                 $this->application->find($nonExistingCommandAlias);
-                $this->fail(sprintf('Console command "%s" should not exist', $nonExistingCommandAlias));
-            } catch (CommandNotFoundException $exception) {
-                $this->assertTrue(
+                self::fail(sprintf('Console command "%s" should not exist', $nonExistingCommandAlias));
+            } catch (CommandNotFoundException) {
+                self::assertTrue(
                     true,
                     sprintf('Asserted that console command "%s" does not exist', $nonExistingCommandAlias)
                 );
@@ -41,6 +44,7 @@ abstract class AbstractCommandTestCase extends FixturesAwareTestCase
     protected function setUp(): void
     {
         $kernel = self::bootKernel();
+
         $this->application = new Application($kernel);
     }
 

--- a/tests/Integration/Command/AbstractLoadConnectionTestCase.php
+++ b/tests/Integration/Command/AbstractLoadConnectionTestCase.php
@@ -20,56 +20,61 @@ abstract class AbstractLoadConnectionTestCase extends AbstractFixturesCommandTes
             ],
         ];
 
-        $this->assertEquals($expectedRows, $this->connection->fetchAllAssociative('SELECT * FROM `table_1`'));
-        $this->assertEquals($expectedRows, $this->connection->fetchAllAssociative('SELECT * FROM `table_2`'));
+        self::assertEquals($expectedRows, $this->connection->fetchAllAssociative('SELECT * FROM `table_1`'));
+        self::assertEquals($expectedRows, $this->connection->fetchAllAssociative('SELECT * FROM `table_2`'));
     }
 
     protected function doAssertionsForExecuteAppend(): void
     {
-        $this->assertEquals(2, $this->connection->fetchOne('select count(1) from table_1'));
-        $this->assertEquals(2, $this->connection->fetchOne('select count(1) from table_2'));
-        $this->assertEquals(1, $this->connection->fetchOne('select count(1) from table_1 where `name` = \'name0\''));
-        $this->assertEquals(1, $this->connection->fetchOne('select count(1) from table_2 where `name` = \'name0\''));
-        $this->assertEquals(1, $this->connection->fetchOne('select count(1) from table_1 where `name` = \'name3\''));
-        $this->assertEquals(1, $this->connection->fetchOne('select count(1) from table_2 where `name` = \'name3\''));
+        self::assertEquals(2, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_1`'));
+        self::assertEquals(2, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_2`'));
+        self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_1` WHERE `name` = \'name0\''));
+        self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_2` WHERE `name` = \'name0\''));
+        self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_1` WHERE `name` = \'name3\''));
+        self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_2` WHERE `name` = \'name3\''));
     }
 
     protected function doAssertionsForExecuteNonAppendInteractive(): void
     {
-        $this->assertEquals(1, $this->connection->fetchOne('select count(1) from table_1'));
-        $this->assertEquals(1, $this->connection->fetchOne('select count(1) from table_2'));
-        $this->assertEquals(0, $this->connection->fetchOne('select count(1) from table_1 where `name` = \'name0\''));
-        $this->assertEquals(0, $this->connection->fetchOne('select count(1) from table_2 where `name` = \'name0\''));
-        $this->assertEquals(1, $this->connection->fetchOne('select count(1) from table_1 where `name` = \'name3\''));
-        $this->assertEquals(1, $this->connection->fetchOne('select count(1) from table_2 where `name` = \'name3\''));
+        self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_1`'));
+        self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_2`'));
+        self::assertEquals(0, $this->connection->fetchOne('select count(1) from table_1 where `name` = \'name0\''));
+        self::assertEquals(0, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_2` WHERE `name` = \'name0\''));
+        self::assertEquals(1, $this->connection->fetchOne('select count(1) from table_1 where `name` = \'name3\''));
+        self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_2` WHERE `name` = \'name3\''));
     }
 
     protected function doAssertionsForExecuteNonAppendNonInteractive(): void
     {
-        $this->assertEquals(1, $this->connection->fetchOne('select count(1) from table_1'));
-        $this->assertEquals(1, $this->connection->fetchOne('select count(1) from table_2'));
-        $this->assertEquals(0, $this->connection->fetchOne('select count(1) from table_1 where `name` = \'name0\''));
-        $this->assertEquals(0, $this->connection->fetchOne('select count(1) from table_2 where `name` = \'name0\''));
-        $this->assertEquals(1, $this->connection->fetchOne('select count(1) from table_1 where `name` = \'name3\''));
-        $this->assertEquals(1, $this->connection->fetchOne('select count(1) from table_2 where `name` = \'name3\''));
+        self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_1`'));
+        self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_2`'));
+        self::assertEquals(0, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_1` WHERE `name` = \'name0\''));
+        self::assertEquals(0, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_2` WHERE `name` = \'name0\''));
+        self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_1` WHERE `name` = \'name3\''));
+        self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_2` WHERE `name` = \'name3\''));
     }
 
     protected function preRunCommand(): void
     {
         $this->connection->executeStatement('TRUNCATE `table_1`');
         $this->connection->executeStatement('TRUNCATE `table_2`');
-        $this->connection->executeStatement('INSERT INTO `table_1` (`name`, `description`) VALUES (\'name0\', \'description0\');');
-        $this->connection->executeStatement('INSERT INTO `table_2` (`name`, `description`) VALUES (\'name0\', \'description0\');');
+        $this->connection->executeStatement(
+            'INSERT INTO `table_1` (`name`, `description`) VALUES (\'name0\', \'description0\');'
+        );
+        $this->connection->executeStatement(
+            'INSERT INTO `table_2` (`name`, `description`) VALUES (\'name0\', \'description0\');'
+        );
 
-        $this->assertEquals(1, $this->connection->fetchOne('select count(1) from table_1'));
-        $this->assertEquals(1, $this->connection->fetchOne('select count(1) from table_2'));
-        $this->assertEquals(1, $this->connection->fetchOne('select count(1) from table_1 where `name` = \'name0\''));
-        $this->assertEquals(1, $this->connection->fetchOne('select count(1) from table_2 where `name` = \'name0\''));
+        self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_1`'));
+        self::assertEquals(1, $this->connection->fetchOne('SELECT COUNT(1) FROM `table_2`'));
+        self::assertEquals(1, $this->connection->fetchOne('select count(1) from table_1 where `name` = \'name0\''));
+        self::assertEquals(1, $this->connection->fetchOne('select count(1) from table_2 where `name` = \'name0\''));
     }
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->connection = $this->getFixturesContainer()->get('doctrine.dbal.def_connection');
+
+        $this->connection = $this->getConnection('doctrine.dbal.def_connection');
     }
 }

--- a/tests/Integration/Command/CopyConnectionSchemaCommandTest.php
+++ b/tests/Integration/Command/CopyConnectionSchemaCommandTest.php
@@ -3,16 +3,15 @@ declare(strict_types=1);
 
 namespace Kununu\TestingBundle\Tests\Integration\Command;
 
-use Doctrine\DBAL\Connection;
 use Kununu\TestingBundle\Command\CopyConnectionSchemaCommand;
 use Kununu\TestingBundle\Service\SchemaCopy\SchemaCopyAdapterFactoryInterface;
 use Kununu\TestingBundle\Service\SchemaCopy\SchemaCopyAdapterInterface;
 
 final class CopyConnectionSchemaCommandTest extends AbstractCommandTestCase
 {
-    private const COMMAND = 'kununu_testing:connections:schema:copy';
+    private const string COMMAND = 'kununu_testing:connections:schema:copy';
 
-    private const TABLES = [
+    private const array TABLES = [
         'doctrine_migration_versions',
         'table_1',
         'table_2',
@@ -20,7 +19,7 @@ final class CopyConnectionSchemaCommandTest extends AbstractCommandTestCase
         'table_to_exclude',
     ];
 
-    private const VIEWS = [
+    private const array VIEWS = [
         'my_view',
     ];
 
@@ -30,37 +29,37 @@ final class CopyConnectionSchemaCommandTest extends AbstractCommandTestCase
     {
         $this->executeCommand('monolithic', 'monolithic_test', '', false);
 
-        $this->assertEquals(0, $this->commandTester->getStatusCode());
-        $this->assertEquals(self::TABLES, $this->adapter->getTables());
-        $this->assertEquals(self::VIEWS, $this->adapter->getViews());
+        self::assertEquals(0, $this->commandTester->getStatusCode());
+        self::assertEquals(self::TABLES, $this->adapter->getTables());
+        self::assertEquals(self::VIEWS, $this->adapter->getViews());
     }
 
     public function testCommandValidInteractiveConfirmed(): void
     {
         $this->executeCommand('monolithic', 'monolithic_test');
 
-        $this->assertEquals(0, $this->commandTester->getStatusCode());
-        $this->assertEquals(self::TABLES, $this->adapter->getTables());
-        $this->assertEquals(self::VIEWS, $this->adapter->getViews());
+        self::assertEquals(0, $this->commandTester->getStatusCode());
+        self::assertEquals(self::TABLES, $this->adapter->getTables());
+        self::assertEquals(self::VIEWS, $this->adapter->getViews());
     }
 
     public function testCommandValidInteractiveNotConfirmed(): void
     {
         $this->executeCommand('monolithic', 'monolithic_test', 'no');
 
-        $this->assertEquals(1, $this->commandTester->getStatusCode());
-        $this->assertEmpty($this->adapter->getTables());
-        $this->assertEmpty($this->adapter->getViews());
+        self::assertEquals(1, $this->commandTester->getStatusCode());
+        self::assertEmpty($this->adapter->getTables());
+        self::assertEmpty($this->adapter->getViews());
     }
 
     public function testCommandInvalidNoArgs(): void
     {
         $this->executeCommand(null, null);
 
-        $this->assertEquals(2, $this->commandTester->getStatusCode());
-        $this->assertEmpty($this->adapter->getTables());
-        $this->assertEmpty($this->adapter->getViews());
-        $this->assertStringContainsString(
+        self::assertEquals(2, $this->commandTester->getStatusCode());
+        self::assertEmpty($this->adapter->getTables());
+        self::assertEmpty($this->adapter->getViews());
+        self::assertStringContainsString(
             '--from" argument can not be empty',
             $this->commandTester->getDisplay()
         );
@@ -70,10 +69,10 @@ final class CopyConnectionSchemaCommandTest extends AbstractCommandTestCase
     {
         $this->executeCommand('i_do_not_exist', null);
 
-        $this->assertEquals(2, $this->commandTester->getStatusCode());
-        $this->assertEmpty($this->adapter->getTables());
-        $this->assertEmpty($this->adapter->getViews());
-        $this->assertStringContainsString(
+        self::assertEquals(2, $this->commandTester->getStatusCode());
+        self::assertEmpty($this->adapter->getTables());
+        self::assertEmpty($this->adapter->getViews());
+        self::assertStringContainsString(
             'Connection wanted to "--from" argument: "i_do_not_exist" was not found!',
             $this->commandTester->getDisplay()
         );
@@ -83,10 +82,10 @@ final class CopyConnectionSchemaCommandTest extends AbstractCommandTestCase
     {
         $this->executeCommand('monolithic', 'i_do_not_exist');
 
-        $this->assertEquals(2, $this->commandTester->getStatusCode());
-        $this->assertEmpty($this->adapter->getTables());
-        $this->assertEmpty($this->adapter->getViews());
-        $this->assertStringContainsString(
+        self::assertEquals(2, $this->commandTester->getStatusCode());
+        self::assertEmpty($this->adapter->getTables());
+        self::assertEmpty($this->adapter->getViews());
+        self::assertStringContainsString(
             'Connection wanted to "--to" argument: "i_do_not_exist" was not found!',
             $this->commandTester->getDisplay()
         );
@@ -97,12 +96,11 @@ final class CopyConnectionSchemaCommandTest extends AbstractCommandTestCase
         parent::setUp();
 
         /** @var SchemaCopyAdapterFactoryInterface $adapterFactory */
-        $adapterFactory = $this->getFixturesContainer()->get('kununu_testing.schema_copy_adapter_factory');
+        $adapterFactory = $this->getServiceFromContainer('kununu_testing.schema_copy_adapter_factory');
 
-        /** @var Connection $connection */
-        $connection = $this->getFixturesContainer()->get('doctrine.dbal.monolithic_test_connection');
-
-        $this->adapter = $adapterFactory->createAdapter($connection);
+        $this->adapter = $adapterFactory->createAdapter(
+            $this->getConnection('doctrine.dbal.monolithic_test_connection')
+        );
     }
 
     protected function getCommandClass(): string
@@ -129,7 +127,7 @@ final class CopyConnectionSchemaCommandTest extends AbstractCommandTestCase
         ?string $from,
         ?string $to,
         string $confirmation = 'yes',
-        bool $interactive = true
+        bool $interactive = true,
     ): void {
         $args = [];
 

--- a/tests/Integration/Command/LoadCacheFixturesCommandTest.php
+++ b/tests/Integration/Command/LoadCacheFixturesCommandTest.php
@@ -10,33 +10,33 @@ use Psr\Cache\CacheItemPoolInterface;
 
 final class LoadCacheFixturesCommandTest extends AbstractFixturesCommandTestCase
 {
-    private const COMMAND_1 = 'kununu_testing:load_fixtures:cache_pools:app.cache.first';
-    private const COMMAND_2 = 'kununu_testing:load_fixtures:cache_pools:app.cache.second';
+    private const string COMMAND_1 = 'kununu_testing:load_fixtures:cache_pools:app.cache.first';
+    private const string COMMAND_2 = 'kununu_testing:load_fixtures:cache_pools:app.cache.second';
 
     private CacheItemPoolInterface $cachePool;
 
     protected function doAssertionsForExecuteAppend(): void
     {
-        $this->assertCacheValue(true, 'key_1', 'value_1');
-        $this->assertCacheValue(true, 'key_2', 'value_2');
-        $this->assertCacheValue(true, 'key_3', 'value_3');
-        $this->assertCacheValue(true, 'existing_key', 'existing_value');
+        self::assertCacheValue($this->cachePool, true, 'key_1', 'value_1');
+        self::assertCacheValue($this->cachePool, true, 'key_2', 'value_2');
+        self::assertCacheValue($this->cachePool, true, 'key_3', 'value_3');
+        self::assertCacheValue($this->cachePool, true, 'existing_key', 'existing_value');
     }
 
     protected function doAssertionsForExecuteNonAppendInteractive(): void
     {
-        $this->assertCacheValue(true, 'key_1', 'value_1');
-        $this->assertCacheValue(true, 'key_2', 'value_2');
-        $this->assertCacheValue(true, 'key_3', 'value_3');
-        $this->assertCacheValue(false, 'existing_key');
+        self::assertCacheValue($this->cachePool, true, 'key_1', 'value_1');
+        self::assertCacheValue($this->cachePool, true, 'key_2', 'value_2');
+        self::assertCacheValue($this->cachePool, true, 'key_3', 'value_3');
+        self::assertCacheValue($this->cachePool, false, 'existing_key');
     }
 
     protected function doAssertionsForExecuteNonAppendNonInteractive(): void
     {
-        $this->assertCacheValue(true, 'key_1', 'value_1');
-        $this->assertCacheValue(true, 'key_2', 'value_2');
-        $this->assertCacheValue(true, 'key_3', 'value_3');
-        $this->assertCacheValue(false, 'existing_key');
+        self::assertCacheValue($this->cachePool, true, 'key_1', 'value_1');
+        self::assertCacheValue($this->cachePool, true, 'key_2', 'value_2');
+        self::assertCacheValue($this->cachePool, true, 'key_3', 'value_3');
+        self::assertCacheValue($this->cachePool, false, 'existing_key');
     }
 
     protected function getCommandClass(): string
@@ -58,26 +58,31 @@ final class LoadCacheFixturesCommandTest extends AbstractFixturesCommandTestCase
     {
         $this->loadCachePoolFixtures('app.cache.first', Options::create(), CachePoolFixture3::class);
 
-        $this->assertCacheValue(false, 'key_1');
-        $this->assertCacheValue(false, 'key_2');
-        $this->assertCacheValue(false, 'key_3');
-        $this->assertCacheValue(true, 'existing_key', 'existing_value');
+        self::assertCacheValue($this->cachePool, false, 'key_1');
+        self::assertCacheValue($this->cachePool, false, 'key_2');
+        self::assertCacheValue($this->cachePool, false, 'key_3');
+        self::assertCacheValue($this->cachePool, true, 'existing_key', 'existing_value');
     }
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->cachePool = $this->getFixturesContainer()->get('app.cache.first');
+
+        $this->cachePool = $this->getCachePool('app.cache.first');
     }
 
-    private function assertCacheValue(bool $exists, string $key, $value = null): void
-    {
+    private static function assertCacheValue(
+        CacheItemPoolInterface $cachePool,
+        bool $exists,
+        string $key,
+        $value = null,
+    ): void {
         if ($exists) {
-            $this->assertTrue($this->cachePool->hasItem($key));
-            $this->assertEquals($value, $this->cachePool->getItem($key)->get());
+            self::assertTrue($cachePool->hasItem($key));
+            self::assertEquals($value, $cachePool->getItem($key)->get());
         } else {
-            $this->assertFalse($this->cachePool->hasItem($key));
-            $this->assertNull($this->cachePool->getItem($key)->get());
+            self::assertFalse($cachePool->hasItem($key));
+            self::assertNull($cachePool->getItem($key)->get());
         }
     }
 }

--- a/tests/Integration/Command/LoadConnectionFixturesCommandTest.php
+++ b/tests/Integration/Command/LoadConnectionFixturesCommandTest.php
@@ -7,9 +7,9 @@ use Kununu\TestingBundle\Command\LoadConnectionFixturesCommand;
 
 final class LoadConnectionFixturesCommandTest extends AbstractLoadConnectionTestCase
 {
-    private const COMMAND_1 = 'kununu_testing:load_fixtures:connections:def';
-    private const COMMAND_2 = 'kununu_testing:load_fixtures:connections:persistence';
-    private const COMMAND_3 = 'kununu_testing:load_fixtures:connections:monolithic';
+    private const string COMMAND_1 = 'kununu_testing:load_fixtures:connections:def';
+    private const string COMMAND_2 = 'kununu_testing:load_fixtures:connections:persistence';
+    private const string COMMAND_3 = 'kununu_testing:load_fixtures:connections:monolithic';
 
     protected function getCommandClass(): string
     {

--- a/tests/Integration/Command/LoadElasticsearchFixturesCommandTest.php
+++ b/tests/Integration/Command/LoadElasticsearchFixturesCommandTest.php
@@ -10,24 +10,24 @@ use Kununu\TestingBundle\Tests\App\Fixtures\Elasticsearch\ElasticsearchFixture1;
 
 final class LoadElasticsearchFixturesCommandTest extends AbstractFixturesCommandTestCase
 {
-    private const COMMAND_1 = 'kununu_testing:load_fixtures:elastic_search:my_index_alias';
-    private const COMMAND_2 = 'kununu_testing:load_fixtures:elastic_search:my_index_alias_2';
+    private const string COMMAND_1 = 'kununu_testing:load_fixtures:elastic_search:my_index_alias';
+    private const string COMMAND_2 = 'kununu_testing:load_fixtures:elastic_search:my_index_alias_2';
 
-    private Client $elasticsearchClient;
+    private Client $client;
 
     protected function doAssertionsForExecuteAppend(): void
     {
-        $this->assertEquals(2, $this->countDocumentsInIndex());
+        self::assertEquals(2, $this->countDocumentsInIndex());
     }
 
     protected function doAssertionsForExecuteNonAppendInteractive(): void
     {
-        $this->assertEquals(1, $this->countDocumentsInIndex());
+        self::assertEquals(1, $this->countDocumentsInIndex());
     }
 
     protected function doAssertionsForExecuteNonAppendNonInteractive(): void
     {
-        $this->assertEquals(1, $this->countDocumentsInIndex());
+        self::assertEquals(1, $this->countDocumentsInIndex());
     }
 
     protected function getCommandClass(): string
@@ -49,17 +49,18 @@ final class LoadElasticsearchFixturesCommandTest extends AbstractFixturesCommand
     {
         $this->loadElasticsearchFixtures('my_index_alias', Options::create(), ElasticsearchFixture1::class);
 
-        $this->assertEquals(1, $this->countDocumentsInIndex());
+        self::assertEquals(1, $this->countDocumentsInIndex());
     }
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->elasticsearchClient = $this->getFixturesContainer()->get(Client::class);
+
+        $this->client = $this->getElasticsearchClient();
     }
 
     private function countDocumentsInIndex(): int
     {
-        return $this->elasticsearchClient->count(['index' => 'my_index'])['count'];
+        return $this->client->count(['index' => 'my_index'])['count'];
     }
 }

--- a/tests/Integration/Command/LoadNonTransactionalConnectionFixturesCommandTest.php
+++ b/tests/Integration/Command/LoadNonTransactionalConnectionFixturesCommandTest.php
@@ -7,9 +7,9 @@ use Kununu\TestingBundle\Command\LoadNonTransactionalConnectionFixturesCommand;
 
 final class LoadNonTransactionalConnectionFixturesCommandTest extends AbstractLoadConnectionTestCase
 {
-    private const COMMAND_1 = 'kununu_testing:load_fixtures:non_transactional_connections:def';
-    private const COMMAND_2 = 'kununu_testing:load_fixtures:non_transactional_connections:persistence';
-    private const COMMAND_3 = 'kununu_testing:load_fixtures:non_transactional_connections:monolithic';
+    private const string COMMAND_1 = 'kununu_testing:load_fixtures:non_transactional_connections:def';
+    private const string COMMAND_2 = 'kununu_testing:load_fixtures:non_transactional_connections:persistence';
+    private const string COMMAND_3 = 'kununu_testing:load_fixtures:non_transactional_connections:monolithic';
 
     protected function getCommandClass(): string
     {

--- a/tests/Integration/Test/AbstractTestCaseTest.php
+++ b/tests/Integration/Test/AbstractTestCaseTest.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\TestingBundle\Tests\Integration\Test;
+
+use Kununu\TestingBundle\Test\AbstractTestCase;
+use Kununu\TestingBundle\Tests\App\Elasticsearch\ClientFactory;
+use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+final class AbstractTestCaseTest extends AbstractTestCase
+{
+    private const string EXISTING_PARAM = 'dummy_param';
+    private const string NON_EXISTING_PARAM = 'non_existing_param';
+
+    private const string EXISTING_SERVICE = ClientFactory::class;
+    private const string NON_EXISTING_SERVICE = 'non_existing_service';
+
+    public function testGetServiceFromContainer(): void
+    {
+        self::assertTrue($this->getFixturesContainer()->has(self::EXISTING_SERVICE));
+        self::assertInstanceOf(ClientFactory::class, $this->getServiceFromContainer(self::EXISTING_SERVICE));
+
+        self::assertFalse($this->getFixturesContainer()->has(self::NON_EXISTING_SERVICE));
+
+        $this->expectException(ServiceNotFoundException::class);
+
+        $this->getServiceFromContainer(self::NON_EXISTING_SERVICE);
+    }
+
+    public function testGetParameterFromContainer(): void
+    {
+        self::assertTrue($this->getFixturesContainer()->hasParameter(self::EXISTING_PARAM));
+        self::assertEquals('i am a parameter', $this->getParameterFromContainer(self::EXISTING_PARAM));
+
+        self::assertFalse($this->getFixturesContainer()->hasParameter(self::NON_EXISTING_PARAM));
+
+        $this->expectException(ParameterNotFoundException::class);
+
+        $this->getParameterFromContainer(self::NON_EXISTING_PARAM);
+    }
+}

--- a/tests/Integration/Test/FixturesAwareTestCaseCachePoolTest.php
+++ b/tests/Integration/Test/FixturesAwareTestCaseCachePoolTest.php
@@ -3,15 +3,18 @@ declare(strict_types=1);
 
 namespace Kununu\TestingBundle\Tests\Integration\Test;
 
+use Kununu\TestingBundle\Test\FixturesAwareTestCase;
+use Kununu\TestingBundle\Test\FixturesContainerGetterTrait;
+use Kununu\TestingBundle\Test\Options\Options;
 use Kununu\TestingBundle\Tests\App\Fixtures\CachePool\CachePoolFixture1;
 use Kununu\TestingBundle\Tests\App\Fixtures\CachePool\CachePoolFixture2;
-use Kununu\TestingBundle\Test\FixturesAwareTestCase;
-use Kununu\TestingBundle\Test\Options\Options;
 use Psr\Cache\CacheItemPoolInterface;
 
 final class FixturesAwareTestCaseCachePoolTest extends FixturesAwareTestCase
 {
-    private const EXTRA_DATA_FOR_INIT = 'some extra data for init';
+    use FixturesContainerGetterTrait;
+
+    private const string EXTRA_DATA_FOR_INIT = 'some extra data for init';
 
     private CacheItemPoolInterface $cachePool;
     private CacheItemPoolInterface $tagAwareCachePool;
@@ -41,10 +44,10 @@ final class FixturesAwareTestCaseCachePoolTest extends FixturesAwareTestCase
         $cachePool1Item2 = $this->cachePool->getItem('key_2');
         $cachePool1Item3 = $this->cachePool->getItem('key_3');
 
-        $this->assertNull($cachePool1ItemAfterPurge1->get());
-        $this->assertEquals('value_1', $cachePool1Item1->get());
-        $this->assertEquals('value_2', $cachePool1Item2->get());
-        $this->assertEquals('value_3', $cachePool1Item3->get());
+        self::assertNull($cachePool1ItemAfterPurge1->get());
+        self::assertEquals('value_1', $cachePool1Item1->get());
+        self::assertEquals('value_2', $cachePool1Item2->get());
+        self::assertEquals('value_3', $cachePool1Item3->get());
     }
 
     public function testLoadCachePoolFixturesWithAppend(): void
@@ -65,10 +68,10 @@ final class FixturesAwareTestCaseCachePoolTest extends FixturesAwareTestCase
         $cachePool1Item2 = $this->cachePool->getItem('key_2');
         $cachePool1Item3 = $this->cachePool->getItem('key_3');
 
-        $this->assertEquals('value_to_not_purge_1', $cachePool1ItemAfterToNotPurge1->get());
-        $this->assertEquals('value_1', $cachePool1Item1->get());
-        $this->assertEquals('value_2', $cachePool1Item2->get());
-        $this->assertEquals('value_3', $cachePool1Item3->get());
+        self::assertEquals('value_to_not_purge_1', $cachePool1ItemAfterToNotPurge1->get());
+        self::assertEquals('value_1', $cachePool1Item1->get());
+        self::assertEquals('value_2', $cachePool1Item2->get());
+        self::assertEquals('value_3', $cachePool1Item3->get());
     }
 
     public function testLoadTagAwareCachePoolFixturesWithoutAppend(): void
@@ -96,10 +99,10 @@ final class FixturesAwareTestCaseCachePoolTest extends FixturesAwareTestCase
         $cachePool1Item2 = $this->tagAwareCachePool->getItem('key_2');
         $cachePool1Item3 = $this->tagAwareCachePool->getItem('key_3');
 
-        $this->assertNull($cachePool1ItemAfterPurge1->get());
-        $this->assertEquals('value_1', $cachePool1Item1->get());
-        $this->assertEquals('value_2', $cachePool1Item2->get());
-        $this->assertEquals('value_3', $cachePool1Item3->get());
+        self::assertNull($cachePool1ItemAfterPurge1->get());
+        self::assertEquals('value_1', $cachePool1Item1->get());
+        self::assertEquals('value_2', $cachePool1Item2->get());
+        self::assertEquals('value_3', $cachePool1Item3->get());
     }
 
     public function testLoadTagAwareCachePoolFixturesWithAppend(): void
@@ -120,10 +123,10 @@ final class FixturesAwareTestCaseCachePoolTest extends FixturesAwareTestCase
         $cachePool1Item2 = $this->tagAwareCachePool->getItem('key_2');
         $cachePool1Item3 = $this->tagAwareCachePool->getItem('key_3');
 
-        $this->assertEquals('value_to_not_purge_1', $cachePool1ItemAfterToNotPurge1->get());
-        $this->assertEquals('value_1', $cachePool1Item1->get());
-        $this->assertEquals('value_2', $cachePool1Item2->get());
-        $this->assertEquals('value_3', $cachePool1Item3->get());
+        self::assertEquals('value_to_not_purge_1', $cachePool1ItemAfterToNotPurge1->get());
+        self::assertEquals('value_1', $cachePool1Item1->get());
+        self::assertEquals('value_2', $cachePool1Item2->get());
+        self::assertEquals('value_3', $cachePool1Item3->get());
     }
 
     public function testLoadTagAwarePoolCachePoolFixturesWithoutAppend(): void
@@ -151,10 +154,10 @@ final class FixturesAwareTestCaseCachePoolTest extends FixturesAwareTestCase
         $cachePool1Item2 = $this->tagAwarePoolCachePool->getItem('key_2');
         $cachePool1Item3 = $this->tagAwarePoolCachePool->getItem('key_3');
 
-        $this->assertNull($cachePool1ItemAfterPurge1->get());
-        $this->assertEquals('value_1', $cachePool1Item1->get());
-        $this->assertEquals('value_2', $cachePool1Item2->get());
-        $this->assertEquals('value_3', $cachePool1Item3->get());
+        self::assertNull($cachePool1ItemAfterPurge1->get());
+        self::assertEquals('value_1', $cachePool1Item1->get());
+        self::assertEquals('value_2', $cachePool1Item2->get());
+        self::assertEquals('value_3', $cachePool1Item3->get());
     }
 
     public function testLoadTagAwarePoolCachePoolFixturesWithAppend(): void
@@ -175,10 +178,10 @@ final class FixturesAwareTestCaseCachePoolTest extends FixturesAwareTestCase
         $cachePool1Item2 = $this->tagAwarePoolCachePool->getItem('key_2');
         $cachePool1Item3 = $this->tagAwarePoolCachePool->getItem('key_3');
 
-        $this->assertEquals('value_to_not_purge_1', $cachePool1ItemAfterToNotPurge1->get());
-        $this->assertEquals('value_1', $cachePool1Item1->get());
-        $this->assertEquals('value_2', $cachePool1Item2->get());
-        $this->assertEquals('value_3', $cachePool1Item3->get());
+        self::assertEquals('value_to_not_purge_1', $cachePool1ItemAfterToNotPurge1->get());
+        self::assertEquals('value_1', $cachePool1Item1->get());
+        self::assertEquals('value_2', $cachePool1Item2->get());
+        self::assertEquals('value_3', $cachePool1Item3->get());
     }
 
     public function testLoadChainCachePoolFixturesWithoutAppend(): void
@@ -206,10 +209,10 @@ final class FixturesAwareTestCaseCachePoolTest extends FixturesAwareTestCase
         $cachePool1Item2 = $this->chainCachePool->getItem('key_2');
         $cachePool1Item3 = $this->chainCachePool->getItem('key_3');
 
-        $this->assertNull($cachePool1ItemAfterPurge1->get());
-        $this->assertEquals('value_1', $cachePool1Item1->get());
-        $this->assertEquals('value_2', $cachePool1Item2->get());
-        $this->assertEquals('value_3', $cachePool1Item3->get());
+        self::assertNull($cachePool1ItemAfterPurge1->get());
+        self::assertEquals('value_1', $cachePool1Item1->get());
+        self::assertEquals('value_2', $cachePool1Item2->get());
+        self::assertEquals('value_3', $cachePool1Item3->get());
     }
 
     public function testLoadChainPoolCachePoolFixturesWithAppend(): void
@@ -230,10 +233,10 @@ final class FixturesAwareTestCaseCachePoolTest extends FixturesAwareTestCase
         $cachePool1Item2 = $this->chainCachePool->getItem('key_2');
         $cachePool1Item3 = $this->chainCachePool->getItem('key_3');
 
-        $this->assertEquals('value_to_not_purge_1', $cachePool1ItemAfterToNotPurge1->get());
-        $this->assertEquals('value_1', $cachePool1Item1->get());
-        $this->assertEquals('value_2', $cachePool1Item2->get());
-        $this->assertEquals('value_3', $cachePool1Item3->get());
+        self::assertEquals('value_to_not_purge_1', $cachePool1ItemAfterToNotPurge1->get());
+        self::assertEquals('value_1', $cachePool1Item1->get());
+        self::assertEquals('value_2', $cachePool1Item2->get());
+        self::assertEquals('value_3', $cachePool1Item3->get());
     }
 
     public function testClearFixtures(): void
@@ -245,14 +248,15 @@ final class FixturesAwareTestCaseCachePoolTest extends FixturesAwareTestCase
             CachePoolFixture2::class
         );
         $this->clearCachePoolFixtures('app.cache.fifth');
-        $this->assertEmpty($this->getCachePoolFixtures('app.cache.fifth'));
+
+        self::assertEmpty($this->getCachePoolFixtures('app.cache.fifth'));
     }
 
     protected function setUp(): void
     {
-        $this->cachePool = $this->getFixturesContainer()->get('app.cache.first');
-        $this->tagAwareCachePool = $this->getFixturesContainer()->get('app.cache.third');
-        $this->tagAwarePoolCachePool = $this->getFixturesContainer()->get('app.cache.fourth');
-        $this->chainCachePool = $this->getFixturesContainer()->get('app.cache.fifth');
+        $this->cachePool = $this->getCachePool('app.cache.first');
+        $this->tagAwareCachePool = $this->getCachePool('app.cache.third');
+        $this->tagAwarePoolCachePool = $this->getCachePool('app.cache.fourth');
+        $this->chainCachePool = $this->getCachePool('app.cache.fifth');
     }
 }

--- a/tests/Integration/Test/FixturesAwareTestCaseConnectionsTest.php
+++ b/tests/Integration/Test/FixturesAwareTestCaseConnectionsTest.php
@@ -5,12 +5,15 @@ namespace Kununu\TestingBundle\Tests\Integration\Test;
 
 use Doctrine\DBAL\Connection;
 use Kununu\TestingBundle\Test\FixturesAwareTestCase;
+use Kununu\TestingBundle\Test\FixturesContainerGetterTrait;
 use Kununu\TestingBundle\Test\Options\DbOptions;
 use Kununu\TestingBundle\Tests\App\Fixtures\Connection\ConnectionFixture1;
 use Kununu\TestingBundle\Tests\App\Fixtures\Connection\ConnectionSqlFixture1;
 
 final class FixturesAwareTestCaseConnectionsTest extends FixturesAwareTestCase
 {
+    use FixturesContainerGetterTrait;
+
     private Connection $defConnection;
     private Connection $monolithicConnection;
 
@@ -45,13 +48,13 @@ final class FixturesAwareTestCaseConnectionsTest extends FixturesAwareTestCase
             ConnectionSqlFixture1::class
         );
 
-        $this->assertEquals(4, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_1`'));
-        $this->assertEquals(4, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_2`'));
-        $this->assertEquals(1, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_to_exclude`'));
+        self::assertEquals(4, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_1`'));
+        self::assertEquals(4, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_2`'));
+        self::assertEquals(1, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_to_exclude`'));
 
-        $this->assertEquals(4, (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM `table_1`'));
-        $this->assertEquals(4, (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM `table_2`'));
-        $this->assertEquals(
+        self::assertEquals(4, (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM `table_1`'));
+        self::assertEquals(4, (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM `table_2`'));
+        self::assertEquals(
             1,
             (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM `table_to_exclude`')
         );
@@ -75,13 +78,13 @@ final class FixturesAwareTestCaseConnectionsTest extends FixturesAwareTestCase
             ConnectionSqlFixture1::class
         );
 
-        $this->assertEquals(3, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_1`'));
-        $this->assertEquals(3, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_2`'));
-        $this->assertEquals(1, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_to_exclude`'));
+        self::assertEquals(3, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_1`'));
+        self::assertEquals(3, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_2`'));
+        self::assertEquals(1, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_to_exclude`'));
 
-        $this->assertEquals(3, (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM table_1'));
-        $this->assertEquals(3, (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM table_2'));
-        $this->assertEquals(
+        self::assertEquals(3, (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM table_1'));
+        self::assertEquals(3, (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM table_2'));
+        self::assertEquals(
             1,
             (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM `table_to_exclude`')
         );
@@ -98,13 +101,13 @@ final class FixturesAwareTestCaseConnectionsTest extends FixturesAwareTestCase
         );
         $this->clearDbFixtures('def', $options);
 
-        $this->assertEmpty($this->getDbFixtures('def', $options));
+        self::assertEmpty($this->getDbFixtures('def', $options));
     }
 
     protected function setUp(): void
     {
-        $this->defConnection = $this->getFixturesContainer()->get('doctrine.dbal.def_connection');
-        $this->monolithicConnection = $this->getFixturesContainer()->get('doctrine.dbal.monolithic_connection');
+        $this->defConnection = $this->getConnection('doctrine.dbal.def_connection');
+        $this->monolithicConnection = $this->getConnection('doctrine.dbal.monolithic_connection');
 
         /** @var Connection $connection */
         foreach ([$this->defConnection, $this->monolithicConnection] as $connection) {

--- a/tests/Integration/Test/FixturesAwareTestCaseElasticsearchTest.php
+++ b/tests/Integration/Test/FixturesAwareTestCaseElasticsearchTest.php
@@ -6,12 +6,15 @@ namespace Kununu\TestingBundle\Tests\Integration\Test;
 use Elasticsearch\Client;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
 use Kununu\TestingBundle\Test\FixturesAwareTestCase;
+use Kununu\TestingBundle\Test\FixturesContainerGetterTrait;
 use Kununu\TestingBundle\Test\Options\Options;
 use Kununu\TestingBundle\Tests\App\Fixtures\Elasticsearch\ElasticsearchFixture1;
 use Kununu\TestingBundle\Tests\App\Fixtures\Elasticsearch\ElasticsearchFixture2;
 
 final class FixturesAwareTestCaseElasticsearchTest extends FixturesAwareTestCase
 {
+    use FixturesContainerGetterTrait;
+
     private Client $client;
 
     public function testLoadElasticSearchFixturesWithoutAppend(): void
@@ -42,7 +45,7 @@ final class FixturesAwareTestCaseElasticsearchTest extends FixturesAwareTestCase
 
         try {
             $purgedDocument = $this->client->get(['index' => 'my_index', 'id' => 'document_to_purge']);
-        } catch (Missing404Exception $missing404Exception) {
+        } catch (Missing404Exception) {
         }
 
         if (!empty($purgedDocument)) {
@@ -52,8 +55,8 @@ final class FixturesAwareTestCaseElasticsearchTest extends FixturesAwareTestCase
         $document1 = $this->client->get(['index' => 'my_index', 'id' => 'my_id_1']);
         $document2 = $this->client->get(['index' => 'my_index', 'id' => 'my_id_2']);
 
-        $this->assertEquals('value_1', $document1['_source']['field']);
-        $this->assertEquals('value_2', $document2['_source']['field']);
+        self::assertEquals('value_1', $document1['_source']['field']);
+        self::assertEquals('value_2', $document2['_source']['field']);
     }
 
     public function testLoadElasticSearchFixturesWithAppend(): void
@@ -80,8 +83,8 @@ final class FixturesAwareTestCaseElasticsearchTest extends FixturesAwareTestCase
         $document1 = $this->client->get(['index' => 'my_index', 'id' => 'my_id_1']);
         $document2 = $this->client->get(['index' => 'my_index', 'id' => 'my_id_2']);
 
-        $this->assertEquals('value_1', $document1['_source']['field']);
-        $this->assertEquals('value_2', $document2['_source']['field']);
+        self::assertEquals('value_1', $document1['_source']['field']);
+        self::assertEquals('value_2', $document2['_source']['field']);
     }
 
     public function testClearFixtures(): void
@@ -93,11 +96,12 @@ final class FixturesAwareTestCaseElasticsearchTest extends FixturesAwareTestCase
             ElasticsearchFixture2::class
         );
         $this->clearElasticsearchFixtures('my_index_alias');
-        $this->assertEmpty($this->getElasticsearchFixtures('my_index_alias'));
+
+        self::assertEmpty($this->getElasticsearchFixtures('my_index_alias'));
     }
 
     protected function setUp(): void
     {
-        $this->client = $this->getFixturesContainer()->get(Client::class);
+        $this->client = $this->getElasticsearchClient();
     }
 }

--- a/tests/Integration/Test/FixturesAwareTestCaseHttpClientTest.php
+++ b/tests/Integration/Test/FixturesAwareTestCaseHttpClientTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Kununu\TestingBundle\Tests\Integration\Test;
 
 use Kununu\TestingBundle\Test\FixturesAwareTestCase;
+use Kununu\TestingBundle\Test\FixturesContainerGetterTrait;
 use Kununu\TestingBundle\Test\Options\Options;
 use Kununu\TestingBundle\Tests\App\Fixtures\HttpClient\HttpClientFixture1;
 use Kununu\TestingBundle\Tests\App\Fixtures\HttpClient\HttpClientFixture2;
@@ -13,6 +14,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class FixturesAwareTestCaseHttpClientTest extends FixturesAwareTestCase
 {
+    use FixturesContainerGetterTrait;
+
     private HttpClientInterface $httpClient;
 
     public function testLoadHttpClientFixturesWithAppend(): void
@@ -30,14 +33,16 @@ final class FixturesAwareTestCaseHttpClientTest extends FixturesAwareTestCase
             Request::METHOD_GET,
             'https://my.server/b7dd0cc2-381d-4e92-bc9b-b78245142e0a/data'
         );
-        $this->assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+
+        self::assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
 
         $response = $this->httpClient->request(
             Request::METHOD_GET,
             'https://my.server/f2895c23-28cb-4020-b038-717cca64bf2d/data'
         );
-        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertJsonStringEqualsJsonString(
+
+        self::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        self::assertJsonStringEqualsJsonString(
             <<<'JSON'
 {
     "id": 1000,
@@ -63,14 +68,16 @@ JSON
             Request::METHOD_GET,
             'https://my.server/b7dd0cc2-381d-4e92-bc9b-b78245142e0a/data'
         );
-        $this->assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
+
+        self::assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
 
         $response = $this->httpClient->request(
             Request::METHOD_GET,
             'https://my.server/f2895c23-28cb-4020-b038-717cca64bf2d/data'
         );
-        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertJsonStringEqualsJsonString(
+
+        self::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        self::assertJsonStringEqualsJsonString(
             <<<'JSON'
 {
     "id": 1000,
@@ -96,11 +103,12 @@ JSON
             HttpClientFixture2::class
         );
         $this->clearHttpClientFixtures('http_client');
-        $this->assertEmpty($this->getHttpClientFixtures('http_client'));
+
+        self::assertEmpty($this->getHttpClientFixtures('http_client'));
     }
 
     protected function setUp(): void
     {
-        $this->httpClient = $this->getFixturesContainer()->get('http_client');
+        $this->httpClient = $this->getHttpClient();
     }
 }

--- a/tests/Integration/Test/FixturesAwareTestCaseNonTransactionalConnectionsTest.php
+++ b/tests/Integration/Test/FixturesAwareTestCaseNonTransactionalConnectionsTest.php
@@ -5,12 +5,15 @@ namespace Kununu\TestingBundle\Tests\Integration\Test;
 
 use Doctrine\DBAL\Connection;
 use Kununu\TestingBundle\Test\FixturesAwareTestCase;
+use Kununu\TestingBundle\Test\FixturesContainerGetterTrait;
 use Kununu\TestingBundle\Test\Options\DbOptions;
 use Kununu\TestingBundle\Tests\App\Fixtures\Connection\ConnectionFixture1;
 use Kununu\TestingBundle\Tests\App\Fixtures\Connection\ConnectionSqlFixture1;
 
 final class FixturesAwareTestCaseNonTransactionalConnectionsTest extends FixturesAwareTestCase
 {
+    use FixturesContainerGetterTrait;
+
     private Connection $defConnection;
     private Connection $monolithicConnection;
 
@@ -45,15 +48,15 @@ final class FixturesAwareTestCaseNonTransactionalConnectionsTest extends Fixture
             ConnectionSqlFixture1::class
         );
 
-        $this->assertEquals(4, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_1`'));
-        $this->assertEquals(4, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM table_2'));
-        $this->assertEquals(1, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_to_exclude`'));
+        self::assertEquals(4, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_1`'));
+        self::assertEquals(4, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_2`'));
+        self::assertEquals(1, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_to_exclude`'));
 
-        $this->assertEquals(4, (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM `table_1`'));
-        $this->assertEquals(4, (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM table_2'));
-        $this->assertEquals(
+        self::assertEquals(4, (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM `table_1`'));
+        self::assertEquals(4, (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM `table_2`'));
+        self::assertEquals(
             1,
-            (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM table_to_exclude')
+            (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM `table_to_exclude`')
         );
     }
 
@@ -75,15 +78,15 @@ final class FixturesAwareTestCaseNonTransactionalConnectionsTest extends Fixture
             ConnectionSqlFixture1::class
         );
 
-        $this->assertEquals(3, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_1`'));
-        $this->assertEquals(3, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_2`'));
-        $this->assertEquals(1, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM table_to_exclude'));
+        self::assertEquals(3, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_1`'));
+        self::assertEquals(3, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_2`'));
+        self::assertEquals(1, (int) $this->defConnection->fetchOne('SELECT COUNT(*) FROM `table_to_exclude`'));
 
-        $this->assertEquals(3, (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM table_1'));
-        $this->assertEquals(3, (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM table_2'));
-        $this->assertEquals(
+        self::assertEquals(3, (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM table_1'));
+        self::assertEquals(3, (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM `table_2`'));
+        self::assertEquals(
             1,
-            (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM table_to_exclude')
+            (int) $this->monolithicConnection->fetchOne('SELECT COUNT(*) FROM `table_to_exclude`')
         );
     }
 
@@ -97,13 +100,14 @@ final class FixturesAwareTestCaseNonTransactionalConnectionsTest extends Fixture
             ConnectionSqlFixture1::class
         );
         $this->clearDbFixtures('def', $options);
-        $this->assertEmpty($this->getDbFixtures('def', $options));
+
+        self::assertEmpty($this->getDbFixtures('def', $options));
     }
 
     protected function setUp(): void
     {
-        $this->defConnection = $this->getFixturesContainer()->get('doctrine.dbal.def_connection');
-        $this->monolithicConnection = $this->getFixturesContainer()->get('doctrine.dbal.monolithic_connection');
+        $this->defConnection = $this->getConnection('doctrine.dbal.def_connection');
+        $this->monolithicConnection = $this->getConnection('doctrine.dbal.monolithic_connection');
 
         /** @var Connection $connection */
         foreach ([$this->defConnection, $this->monolithicConnection] as $connection) {

--- a/tests/Integration/Test/Options/DbOptionsTest.php
+++ b/tests/Integration/Test/Options/DbOptionsTest.php
@@ -15,11 +15,11 @@ final class DbOptionsTest extends TestCase
         DbOptionsInterface $options,
         bool $expectedAppend,
         bool $expectedClear,
-        bool $expectedTransactional
+        bool $expectedTransactional,
     ): void {
-        $this->assertEquals($expectedAppend, $options->append());
-        $this->assertEquals($expectedClear, $options->clear());
-        $this->assertEquals($expectedTransactional, $options->transactional());
+        self::assertEquals($expectedAppend, $options->append());
+        self::assertEquals($expectedClear, $options->clear());
+        self::assertEquals($expectedTransactional, $options->transactional());
     }
 
     public static function dbOptionsDataProvider(): array
@@ -31,25 +31,25 @@ final class DbOptionsTest extends TestCase
                 true,
                 true,
             ],
-            'create non transactional'              => [
+            'create_non_transactional'              => [
                 DbOptions::createNonTransactional(),
                 false,
                 true,
                 false,
             ],
-            'without transactional'                 => [
+            'without_transactional'                 => [
                 DbOptions::create()->withoutTransactional(),
                 false,
                 true,
                 false,
             ],
-            'with transactional'                    => [
+            'with_transactional'                    => [
                 DbOptions::create()->withTransactional(),
                 false,
                 true,
                 true,
             ],
-            'with parent options and transactional' => [
+            'with_parent_options_and_transactional' => [
                 DbOptions::create()->withAppend()->withoutClear()->withTransactional(),
                 true,
                 false,

--- a/tests/Integration/Test/Options/OptionsTest.php
+++ b/tests/Integration/Test/Options/OptionsTest.php
@@ -13,8 +13,8 @@ final class OptionsTest extends TestCase
     #[DataProvider('optionsDataProvider')]
     public function testOptions(OptionsInterface $options, bool $expectedAppend, bool $expectedClear): void
     {
-        $this->assertEquals($expectedAppend, $options->append());
-        $this->assertEquals($expectedClear, $options->clear());
+        self::assertEquals($expectedAppend, $options->append());
+        self::assertEquals($expectedClear, $options->clear());
     }
 
     public static function optionsDataProvider(): array
@@ -25,27 +25,27 @@ final class OptionsTest extends TestCase
                 false,
                 true,
             ],
-            'with append'           => [
+            'with_append'           => [
                 Options::create()->withAppend(),
                 true,
                 true,
             ],
-            'without append'        => [
+            'without_append'        => [
                 Options::create()->withoutAppend(),
                 false,
                 true,
             ],
-            'with clear'            => [
+            'with_clear'            => [
                 Options::create()->withClear(),
                 false,
                 true,
             ],
-            'without clear'         => [
+            'without_clear'         => [
                 Options::create()->withoutClear(),
                 false,
                 false,
             ],
-            'with append and clear' => [
+            'with_append_and_clear' => [
                 Options::create()->withAppend()->withClear(),
                 true,
                 true,

--- a/tests/Integration/Test/RequestBuilderTest.php
+++ b/tests/Integration/Test/RequestBuilderTest.php
@@ -15,12 +15,12 @@ final class RequestBuilderTest extends TestCase
 
         [$method, $uri, $parameters, $files, $server, $content] = $request->build();
 
-        $this->assertEquals('GET', $method);
-        $this->assertNull($uri);
-        $this->assertEmpty($parameters);
-        $this->assertEmpty($files);
-        $this->assertEmpty($server);
-        $this->assertNull($content);
+        self::assertEquals('GET', $method);
+        self::assertNull($uri);
+        self::assertEmpty($parameters);
+        self::assertEmpty($files);
+        self::assertEmpty($server);
+        self::assertNull($content);
     }
 
     public function testBuildPostRequest(): void
@@ -29,12 +29,12 @@ final class RequestBuilderTest extends TestCase
 
         [$method, $uri, $parameters, $files, $server, $content] = $request->build();
 
-        $this->assertEquals('POST', $method);
-        $this->assertNull($uri);
-        $this->assertEmpty($parameters);
-        $this->assertEmpty($files);
-        $this->assertEmpty($server);
-        $this->assertNull($content);
+        self::assertEquals('POST', $method);
+        self::assertNull($uri);
+        self::assertEmpty($parameters);
+        self::assertEmpty($files);
+        self::assertEmpty($server);
+        self::assertNull($content);
     }
 
     public function testBuildPostRequestWithParameters(): void
@@ -43,12 +43,12 @@ final class RequestBuilderTest extends TestCase
 
         [$method, $uri, $parameters, $files, $server, $content] = $request->build();
 
-        $this->assertEquals('POST', $method);
-        $this->assertNull($uri);
-        $this->assertEquals(['parameters'], $parameters);
-        $this->assertEmpty($files);
-        $this->assertEmpty($server);
-        $this->assertNull($content);
+        self::assertEquals('POST', $method);
+        self::assertNull($uri);
+        self::assertEquals(['parameters'], $parameters);
+        self::assertEmpty($files);
+        self::assertEmpty($server);
+        self::assertNull($content);
     }
 
     public function testBuildPutRequest(): void
@@ -57,12 +57,12 @@ final class RequestBuilderTest extends TestCase
 
         [$method, $uri, $parameters, $files, $server, $content] = $request->build();
 
-        $this->assertEquals('PUT', $method);
-        $this->assertNull($uri);
-        $this->assertEmpty($parameters);
-        $this->assertEmpty($files);
-        $this->assertEmpty($server);
-        $this->assertNull($content);
+        self::assertEquals('PUT', $method);
+        self::assertNull($uri);
+        self::assertEmpty($parameters);
+        self::assertEmpty($files);
+        self::assertEmpty($server);
+        self::assertNull($content);
     }
 
     public function testBuildPatchRequest(): void
@@ -71,12 +71,12 @@ final class RequestBuilderTest extends TestCase
 
         [$method, $uri, $parameters, $files, $server, $content] = $request->build();
 
-        $this->assertEquals('PATCH', $method);
-        $this->assertNull($uri);
-        $this->assertEmpty($parameters);
-        $this->assertEmpty($files);
-        $this->assertEmpty($server);
-        $this->assertNull($content);
+        self::assertEquals('PATCH', $method);
+        self::assertNull($uri);
+        self::assertEmpty($parameters);
+        self::assertEmpty($files);
+        self::assertEmpty($server);
+        self::assertNull($content);
     }
 
     public function testBuildDeleteRequest(): void
@@ -85,12 +85,12 @@ final class RequestBuilderTest extends TestCase
 
         [$method, $uri, $parameters, $files, $server, $content] = $request->build();
 
-        $this->assertEquals('DELETE', $method);
-        $this->assertNull($uri);
-        $this->assertEmpty($parameters);
-        $this->assertEmpty($files);
-        $this->assertEmpty($server);
-        $this->assertNull($content);
+        self::assertEquals('DELETE', $method);
+        self::assertNull($uri);
+        self::assertEmpty($parameters);
+        self::assertEmpty($files);
+        self::assertEmpty($server);
+        self::assertNull($content);
     }
 
     public function testBuildRequestWithMethod(): void
@@ -98,7 +98,8 @@ final class RequestBuilderTest extends TestCase
         $request = RequestBuilder::aGetRequest()->withMethod('POST');
 
         [$method] = $request->build();
-        $this->assertEquals('POST', $method);
+
+        self::assertEquals('POST', $method);
     }
 
     public function testBuildRequestWithUri(): void
@@ -106,7 +107,8 @@ final class RequestBuilderTest extends TestCase
         $request = RequestBuilder::aGetRequest()->withUri('/v1/uri');
 
         [, $uri] = $request->build();
-        $this->assertEquals('/v1/uri', $uri);
+
+        self::assertEquals('/v1/uri', $uri);
     }
 
     public function testBuildRequestWithContent(): void
@@ -114,7 +116,8 @@ final class RequestBuilderTest extends TestCase
         $request = RequestBuilder::aGetRequest()->withContent(['data' => ['key' => 'value']]);
 
         [, , , , , $content] = $request->build();
-        $this->assertEquals(json_encode(['data' => ['key' => 'value']]), $content);
+
+        self::assertEquals(json_encode(['data' => ['key' => 'value']]), $content);
     }
 
     public function testBuildRequestWithRawContent(): void
@@ -122,7 +125,8 @@ final class RequestBuilderTest extends TestCase
         $request = RequestBuilder::aGetRequest()->withRawContent('just a content');
 
         [, , , , , $content] = $request->build();
-        $this->assertEquals('just a content', $content);
+
+        self::assertEquals('just a content', $content);
     }
 
     public function testBuildRequestWithAuthorization(): void
@@ -130,7 +134,8 @@ final class RequestBuilderTest extends TestCase
         $request = RequestBuilder::aGetRequest()->withAuthorization('ACCESS_TOKEN_VALUE');
 
         [, , , , $server] = $request->build();
-        $this->assertEquals('Bearer ACCESS_TOKEN_VALUE', $server['HTTP_AUTHORIZATION']);
+
+        self::assertEquals('Bearer ACCESS_TOKEN_VALUE', $server['HTTP_AUTHORIZATION']);
     }
 
     #[DataProvider('buildRequestWithHeaderDataProvider')]
@@ -141,7 +146,8 @@ final class RequestBuilderTest extends TestCase
         $request = RequestBuilder::aGetRequest()->withHeader($headerName, $headerValue);
 
         [, , , , $server] = $request->build();
-        $this->assertEquals($headerValue, $server[$expectedHeaderName]);
+
+        self::assertEquals($headerValue, $server[$expectedHeaderName]);
     }
 
     public static function buildRequestWithHeaderDataProvider(): array
@@ -165,6 +171,7 @@ final class RequestBuilderTest extends TestCase
             ->withServerParameter('HTTP_ACCEPT', 'application/json');
 
         [, , , , $server] = $request->build();
-        $this->assertEquals(['REMOTE_ADDR' => '127.0.0.1', 'HTTP_ACCEPT' => 'application/json'], $server);
+
+        self::assertEquals(['REMOTE_ADDR' => '127.0.0.1', 'HTTP_ACCEPT' => 'application/json'], $server);
     }
 }

--- a/tests/Integration/Test/WebTestCaseTest.php
+++ b/tests/Integration/Test/WebTestCaseTest.php
@@ -17,12 +17,12 @@ final class WebTestCaseTest extends WebTestCase
             RequestBuilder::aGetRequest()->withUri('/app/response')
         );
 
-        $this->assertEquals('{"key":"value"}', $response->getContent());
+        self::assertEquals('{"key":"value"}', $response->getContent());
     }
 
     public function testThatExtendsFixturesAwareTestCase(): void
     {
-        $this->assertTrue(is_subclass_of($this, FixturesAwareTestCase::class));
+        self::assertTrue(is_subclass_of($this, FixturesAwareTestCase::class));
     }
 
     public function testThatHttpFixturesGetLoaded(): void
@@ -33,6 +33,6 @@ final class WebTestCaseTest extends WebTestCase
             RequestBuilder::aGetRequest()->withUri('/app/response')
         );
 
-        $this->assertNotEmpty($this->getHttpClientFixtures('http_client'));
+        self::assertNotEmpty($this->getHttpClientFixtures('http_client'));
     }
 }

--- a/tests/Unit/DependencyInjection/Compiler/BaseCompilerPassTestCase.php
+++ b/tests/Unit/DependencyInjection/Compiler/BaseCompilerPassTestCase.php
@@ -14,7 +14,7 @@ abstract class BaseCompilerPassTestCase extends AbstractCompilerPassTestCase
     protected function assertServiceDefinitionWithReferenceArgument(
         string $serviceId,
         string|int $argumentIndex,
-        string $expectedValue
+        string $expectedValue,
     ): void {
         $this->assertContainerBuilderHasServiceDefinitionWithArgument(
             $serviceId,
@@ -29,7 +29,7 @@ abstract class BaseCompilerPassTestCase extends AbstractCompilerPassTestCase
         string $commandClassName,
         string $alias,
         string $orchestratorId,
-        array $fixturesClassesNamespaces
+        array $fixturesClassesNamespaces,
     ): void {
         $this->assertContainerBuilderHasService(
             $commandId,
@@ -60,13 +60,13 @@ abstract class BaseCompilerPassTestCase extends AbstractCompilerPassTestCase
             $fixturesClassesNamespaces
         );
 
-        $this->assertTrue($this->container->getDefinition($orchestratorId)->isPublic());
+        self::assertTrue($this->container->getDefinition($orchestratorId)->isPublic());
     }
 
     protected function assertPurger(string $purgerId, string $purgerClass, mixed ...$arguments): void
     {
         $this->assertContainerBuilderHasService($purgerId, $purgerClass);
-        $this->assertTrue($this->container->getDefinition($purgerId)->isPrivate());
+        self::assertTrue($this->container->getDefinition($purgerId)->isPrivate());
         foreach ($arguments as $position => $argument) {
             $this->assertContainerBuilderHasServiceDefinitionWithArgument($purgerId, $position, $argument);
         }
@@ -75,7 +75,7 @@ abstract class BaseCompilerPassTestCase extends AbstractCompilerPassTestCase
     protected function assertExecutor(string $executorId, string $executorClass, mixed ...$arguments): void
     {
         $this->assertContainerBuilderHasService($executorId, $executorClass);
-        $this->assertTrue($this->container->getDefinition($executorId)->isPrivate());
+        self::assertTrue($this->container->getDefinition($executorId)->isPrivate());
         foreach ($arguments as $position => $argument) {
             $this->assertContainerBuilderHasServiceDefinitionWithArgument($executorId, $position, $argument);
         }
@@ -84,13 +84,13 @@ abstract class BaseCompilerPassTestCase extends AbstractCompilerPassTestCase
     protected function assertLoader(string $loaderId, string $loaderClass): void
     {
         $this->assertContainerBuilderHasService($loaderId, $loaderClass);
-        $this->assertTrue($this->container->getDefinition($loaderId)->isPrivate());
+        self::assertTrue($this->container->getDefinition($loaderId)->isPrivate());
     }
 
     protected function assertOrchestrator(string $orchestratorId, string $executorId, string $loaderId): void
     {
         $this->assertContainerBuilderHasService($orchestratorId, Orchestrator::class);
-        $this->assertTrue($this->container->getDefinition($orchestratorId)->isPublic());
+        self::assertTrue($this->container->getDefinition($orchestratorId)->isPublic());
         $this->assertContainerBuilderHasServiceDefinitionWithArgument($orchestratorId, 0, new Reference($executorId));
         $this->assertContainerBuilderHasServiceDefinitionWithArgument($orchestratorId, 1, new Reference($loaderId));
     }
@@ -100,12 +100,12 @@ abstract class BaseCompilerPassTestCase extends AbstractCompilerPassTestCase
         $mock = $this->createMock(ExtensionInterface::class);
 
         $mock
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getAlias')
             ->willReturn($alias);
 
         $mock
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getNamespace')
             ->willReturn(false);
 

--- a/tests/Unit/DependencyInjection/Compiler/CachePoolCompilerPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/CachePoolCompilerPassTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class CachePoolCompilerPassTest extends BaseCompilerPassTestCase
 {
-    private const CACHE_POOL_IDS = [
+    private const array CACHE_POOL_IDS = [
         'cache_pool.service_1'           => [
             'creates_command' => true,
         ],
@@ -25,7 +25,7 @@ final class CachePoolCompilerPassTest extends BaseCompilerPassTestCase
         ],
     ];
 
-    private const CONFIG = [
+    private const array CONFIG = [
         'cache' => [
             'pools' => [
                 'cache_pool.service_1' => [
@@ -50,7 +50,7 @@ final class CachePoolCompilerPassTest extends BaseCompilerPassTestCase
                 string $orchestratorId,
                 string $cachePoolId,
                 ?string $consoleCommandId,
-                ?string $consoleCommandName
+                ?string $consoleCommandName,
             ): void {
                 $this->assertPurger($purgerId, CachePoolPurger::class, new Reference($cachePoolId));
                 $this->assertExecutor($executorId, CachePoolExecutor::class, new Reference($cachePoolId), new Reference($purgerId));

--- a/tests/Unit/DependencyInjection/Compiler/CopyConnectionSchemaCommandCompilerPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/CopyConnectionSchemaCommandCompilerPassTest.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 final class CopyConnectionSchemaCommandCompilerPassTest extends BaseCompilerPassTestCase
 {
-    private const COMMAND_ID = 'kununu_testing:connections:schema:copy.command';
+    private const string COMMAND_ID = 'kununu_testing:connections:schema:copy.command';
 
     public function testCompileWithDoctrineConnections(): void
     {
@@ -21,7 +21,7 @@ final class CopyConnectionSchemaCommandCompilerPassTest extends BaseCompilerPass
         $this->assertContainerBuilderHasServiceDefinitionWithTag(self::COMMAND_ID, 'console.command');
         $this->assertServiceDefinitionWithReferenceArgument(self::COMMAND_ID, 0, 'kununu_testing.schema_copy');
         $this->assertServiceDefinitionWithReferenceArgument(self::COMMAND_ID, 1, 'doctrine');
-        $this->assertTrue($this->container->getDefinition(self::COMMAND_ID)->isPublic());
+        self::assertTrue($this->container->getDefinition(self::COMMAND_ID)->isPublic());
     }
 
     public function testCompileWithoutDoctrineConnections(): void

--- a/tests/Unit/DependencyInjection/Compiler/ElasticsearchCompilerPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/ElasticsearchCompilerPassTest.php
@@ -15,7 +15,7 @@ final class ElasticsearchCompilerPassTest extends BaseCompilerPassTestCase
 {
     public function testCompile(): void
     {
-        $indexes = [
+        $indices = [
             'alias_1' => [
                 'index_name' => 'index1',
                 'service'    => 'elastic_search_service_1',
@@ -35,11 +35,11 @@ final class ElasticsearchCompilerPassTest extends BaseCompilerPassTestCase
             ],
         ];
 
-        $this->setParameter('kununu_testing.elastic_search', $indexes);
+        $this->setParameter('kununu_testing.elastic_search', $indices);
 
         $this->compile();
 
-        foreach ($indexes as $alias => $config) {
+        foreach ($indices as $alias => $config) {
             $purgerId = sprintf('kununu_testing.orchestrator.elastic_search.%s.purger', $alias);
             $executorId = sprintf('kununu_testing.orchestrator.elastic_search.%s.executor', $alias);
             $loaderId = sprintf('kununu_testing.orchestrator.elastic_search.%s.loader', $alias);

--- a/tests/Unit/DependencyInjection/Compiler/HttpClientCompilerPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/HttpClientCompilerPassTest.php
@@ -13,12 +13,12 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class HttpClientCompilerPassTest extends BaseCompilerPassTestCase
 {
-    private const HTTP_CLIENT_IDS = [
+    private const array HTTP_CLIENT_IDS = [
         'http_client_1',
         'http_client_2',
     ];
 
-    private const CONFIG = [
+    private const array CONFIG = [
         'http_client' => [
             'clients' => self::HTTP_CLIENT_IDS,
         ],
@@ -34,7 +34,7 @@ final class HttpClientCompilerPassTest extends BaseCompilerPassTestCase
                 string $executorId,
                 string $loaderId,
                 string $orchestratorId,
-                string $httpClientId
+                string $httpClientId,
             ): void {
                 $this->assertPurger($purgerId, HttpClientPurger::class, new Reference($httpClientId));
                 $this->assertExecutor(

--- a/tests/Unit/DependencyInjection/ConfigurationTestCase.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTestCase.php
@@ -24,7 +24,7 @@ abstract class ConfigurationTestCase extends TestCase
     public function testInvalidConfigurationForNode(?array $values): void
     {
         if (null === $values) {
-            $this->assertTrue(true);
+            self::assertTrue(true);
         } else {
             $this->assertConfigurationIsInvalid($values, sprintf('kununu_testing.%s', $this->getNodeName()));
         }

--- a/tests/Unit/KununuTestingBundleTest.php
+++ b/tests/Unit/KununuTestingBundleTest.php
@@ -22,10 +22,10 @@ final class KununuTestingBundleTest extends TestCase
 
         $container = $this->createMock(ContainerBuilder::class);
         $container
-            ->expects($this->exactly(6))
+            ->expects(self::exactly(6))
             ->method('addCompilerPass')
             ->willReturnCallback(
-                function($subject) use ($container, &$executedCompilerPasses): MockObject|ContainerBuilder {
+                function($subject) use ($container, &$executedCompilerPasses): MockObject&ContainerBuilder {
                     $executedCompilerPasses[] = $subject::class;
 
                     return $container;
@@ -34,7 +34,7 @@ final class KununuTestingBundleTest extends TestCase
 
         (new KununuTestingBundle())->build($container);
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 CachePoolCompilerPass::class,
                 ConnectionCompilerPass::class,

--- a/tests/Unit/Service/OrchestratorTest.php
+++ b/tests/Unit/Service/OrchestratorTest.php
@@ -3,11 +3,13 @@ declare(strict_types=1);
 
 namespace Kununu\TestingBundle\Tests\Unit\Service;
 
+use DateTime;
 use Kununu\DataFixtures\Executor\ExecutorInterface;
 use Kununu\DataFixtures\FixtureInterface;
 use Kununu\DataFixtures\Loader\LoaderInterface;
 use Kununu\TestingBundle\Service\Orchestrator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class OrchestratorTest extends TestCase
@@ -15,36 +17,36 @@ final class OrchestratorTest extends TestCase
     #[DataProvider('executesAsExpectedDataProvider')]
     public function testThatExecutesAsExpected(bool $append): void
     {
-        $fixture1 = $this->getMockBuilder(FixtureInterface::class)->setMockClassName('Mock1')->getMock();
-        $fixture2 = $this->getMockBuilder(FixtureInterface::class)->setMockClassName('Mock2')->getMock();
+        $fixture1 = $this->getNamedFixtureMock($fixture1Class = $this->generateMockClassName('Mock1'));
+        $fixture2 = $this->getNamedFixtureMock($fixture2Class = $this->generateMockClassName('Mock2'));
 
         $loader = $this->createMock(LoaderInterface::class);
         $loader
-            ->expects($this->exactly(2))
+            ->expects(self::exactly(2))
             ->method('loadFromClassName')
             ->with(
                 $this->callback(fn(string $class): bool => match ($class) {
-                    'Mock1', 'Mock2' => true,
-                    default => false
+                    $fixture1Class, $fixture2Class => true,
+                    default                        => false,
                 })
             );
         $loader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getFixtures')
             ->willReturn([$fixture1, $fixture2]);
         $loader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('clearFixtures');
 
         $executor = $this->createMock(ExecutorInterface::class);
         $executor
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('execute')
             ->with([$fixture1, $fixture2], $append);
 
         $orchestrator = new Orchestrator($executor, $loader);
 
-        $orchestrator->execute(['Mock1', 'Mock2'], $append);
+        $orchestrator->execute([$fixture1Class, $fixture2Class], $append);
     }
 
     public static function executesAsExpectedDataProvider(): array
@@ -53,5 +55,18 @@ final class OrchestratorTest extends TestCase
             'with_append'    => [true],
             'without_append' => [false],
         ];
+    }
+
+    protected function getNamedFixtureMock(string $name): MockObject&FixtureInterface
+    {
+        return $this
+            ->getMockBuilder(FixtureInterface::class)
+            ->setMockClassName($name)
+            ->getMock();
+    }
+
+    private function generateMockClassName(string $prefix): string
+    {
+        return sprintf('%s%s', $prefix, md5((new DateTime())->format('Y-m-d H:i:s.uP')));
     }
 }

--- a/tests/Unit/Service/SchemaCopy/Adapter/MySqlAdapterTest.php
+++ b/tests/Unit/Service/SchemaCopy/Adapter/MySqlAdapterTest.php
@@ -11,17 +11,17 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 final class MySqlAdapterTest extends SchemaCopyTestCase
 {
-    private MockObject|Connection $connection;
+    private MockObject&Connection $connection;
     private SchemaCopyAdapterInterface $adapter;
 
     public function testSameTypeAsEqual(): void
     {
-        $this->assertTrue($this->adapter->sameTypeAs($this->adapter));
+        self::assertTrue($this->adapter->sameTypeAs($this->adapter));
     }
 
     public function testSameTypeAsNotEqual(): void
     {
-        $this->assertFalse($this->adapter->sameTypeAs($this->createAdapter('IT IS DIFFERENT!')));
+        self::assertFalse($this->adapter->sameTypeAs($this->createAdapter('IT IS DIFFERENT!')));
     }
 
     public function testRunCopy(): void
@@ -40,7 +40,7 @@ final class MySqlAdapterTest extends SchemaCopyTestCase
             $value = true;
         });
 
-        $this->assertTrue($value);
+        self::assertTrue($value);
     }
 
     public function testDisableConstraints(): void

--- a/tests/Unit/Service/SchemaCopy/Copier/SchemaCopierTest.php
+++ b/tests/Unit/Service/SchemaCopy/Copier/SchemaCopierTest.php
@@ -16,21 +16,21 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 final class SchemaCopierTest extends SchemaCopyTestCase
 {
-    private MockObject|Connection $source;
-    private MockObject|Connection $destination;
-    private MockObject|SchemaCopyAdapterFactoryInterface $factory;
+    private MockObject&Connection $source;
+    private MockObject&Connection $destination;
+    private MockObject&SchemaCopyAdapterFactoryInterface $factory;
     private SchemaCopyInterface $copier;
 
     public function testCopy(): void
     {
         $this->factory
-            ->expects($this->exactly(2))
+            ->expects(self::exactly(2))
             ->method('createAdapter')
             ->willReturnCallback(
                 fn(Connection $connection): SchemaCopyAdapterInterface => match ($connection) {
                     $this->source      => new MySqlAdapter($this->source),
                     $this->destination => new MySqlAdapter($this->destination),
-                    default            => throw new LogicException('Unknown connection')
+                    default            => throw new LogicException('Unknown connection'),
                 }
             );
 
@@ -94,13 +94,13 @@ final class SchemaCopierTest extends SchemaCopyTestCase
     public function testCopyWithIncompatibleAdapters(): void
     {
         $this->factory
-            ->expects($this->exactly(2))
+            ->expects(self::exactly(2))
             ->method('createAdapter')
             ->willReturnCallback(
                 fn(Connection $connection): SchemaCopyAdapterInterface => match ($connection) {
                     $this->source      => new MySqlAdapter($this->source),
                     $this->destination => $this->createAdapter('YourSql', 2),
-                    default            => throw new LogicException('Unknown connection')
+                    default            => throw new LogicException('Unknown connection'),
                 }
             );
 
@@ -114,7 +114,6 @@ final class SchemaCopierTest extends SchemaCopyTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
         $this->source = $this->createConnection();
         $this->destination = $this->createConnection();
         $this->factory = $this->createMock(SchemaCopyAdapterFactoryInterface::class);

--- a/tests/Unit/Service/SchemaCopy/Factory/AdapterFactoryTest.php
+++ b/tests/Unit/Service/SchemaCopy/Factory/AdapterFactoryTest.php
@@ -18,7 +18,7 @@ final class AdapterFactoryTest extends TestCase
     {
         $connection = $this->createMock(Connection::class);
         $connection
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getDatabasePlatform')
             ->willReturn($this->createMock($platformClass));
 
@@ -29,7 +29,7 @@ final class AdapterFactoryTest extends TestCase
         $adapter = (new AdapterFactory())->createAdapter($connection);
 
         if (null !== $expectedType) {
-            $this->assertEquals($expectedType, $adapter->type());
+            self::assertEquals($expectedType, $adapter->type());
         }
     }
 

--- a/tests/Unit/Service/SchemaCopy/SchemaCopyTestCase.php
+++ b/tests/Unit/Service/SchemaCopy/SchemaCopyTestCase.php
@@ -15,63 +15,59 @@ abstract class SchemaCopyTestCase extends TestCase
 {
     protected string $fetchAllFirstColumnMethod;
 
-    protected function createAdapter(string $type, int $expectedCalls = 1): MockObject|SchemaCopyAdapterInterface
+    protected function createAdapter(string $type, int $expectedCalls = 1): MockObject&SchemaCopyAdapterInterface
     {
         $adapter = $this->createMock(SchemaCopyAdapterInterface::class);
         $adapter
-            ->expects($this->exactly($expectedCalls))
+            ->expects(self::exactly($expectedCalls))
             ->method('type')
             ->willReturn($type);
 
         return $adapter;
     }
 
-    protected function createConnection(): MockObject|Connection
+    protected function createConnection(): MockObject&Connection
     {
         $connection = $this->createMock(Connection::class);
         $connection
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getDatabasePlatform')
             ->willReturn($this->createMock(MySQL80Platform::class));
 
         return $connection;
     }
 
-    protected function mockExecuteQuery(MockObject|Connection $connection, array $results, string ...$statements): void
+    protected function mockExecuteQuery(MockObject&Connection $connection, array $results, string ...$statements): void
     {
         $map = array_combine($statements, $results);
 
         $connection
-            ->expects($this->exactly(count($statements)))
+            ->expects(self::exactly(count($statements)))
             ->method('executeQuery')
-            ->willReturnCallback(function(string $statement) use ($map): Result {
-                switch (true) {
-                    case isset($map[$statement]):
-                        return $map[$statement];
-                    default:
-                        return throw new LogicException(sprintf('Statement "%s" not found', $statement));
-                }
+            ->willReturnCallback(fn(string $statement): Result => match (true) {
+                isset($map[$statement]) => $map[$statement],
+                default                 => throw new LogicException(sprintf('Statement "%s" not found', $statement)),
             });
     }
 
-    protected function mockExecuteStatement(MockObject|Connection $connection, string ...$statements): void
+    protected function mockExecuteStatement(MockObject&Connection $connection, string ...$statements): void
     {
         $map = array_combine($statements, array_fill(0, count($statements), 0));
 
         $connection
-            ->expects($this->exactly(count($statements)))
+            ->expects(self::exactly(count($statements)))
             ->method('executeStatement')
             ->willReturnCallback(fn(string $statement): int => match (true) {
                 isset($map[$statement]) => $map[$statement],
-                default                 => throw new LogicException(sprintf('Statement "%s" not found', $statement))
+                default                 => throw new LogicException(sprintf('Statement "%s" not found', $statement)),
             });
     }
 
-    protected function createResult(string $method, mixed $return): MockObject|Result
+    protected function createResult(string $method, mixed $return): MockObject&Result
     {
         $result = $this->createMock(Result::class);
         $result
-            ->expects($this->once())
+            ->expects(self::once())
             ->method($method)
             ->withAnyParameters()
             ->willReturn($return);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,5 +4,11 @@ declare(strict_types=1);
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\ErrorHandler\ErrorHandler;
+
+// PHPUnit 11 conflicts with Symfony error handler and make all functional tests being marked as risky
+// with "Test code or tested code did not remove its own exception handlers"
+// https://github.com/symfony/symfony/issues/53812#issuecomment-1962740145
+set_exception_handler([new ErrorHandler(), 'handleException']);
 
 (new Dotenv())->bootEnv(dirname(__DIR__) . '/tests/App/.env');


### PR DESCRIPTION
# Description

The objective of this PR is to make the bundle support only PHP 8.3 and take advantage of it.

## Details

**BREAKING CHANGES**
- Only support PHP 8.3 - Make classes read-only when possible
  - Add types to constants
  - Upgrade PHPUnit to v11.3
    - Use static versions of asserts and expectations of invocations
  - Change CI pipeline to use PHP 8.3
  - Bump to use `kununu/data-fixtures` 12.0
- Changes on `AbstractTestCase` and children (`FixturesAwareTestCase` and `WebTestCase`):
  - `getFixturesContainer` now has the Symfony `ContainerInterface` and not PSR interface as its return type
  - Add `getServiceFromContainer`
  - Add `getParameterFromContainer`
- Add `FixturesContainerGetterTrait` to help getting common services from the test container:
  - `getConnection` to get a Doctrine DBAL connection
  - `getCachePool` to get a CacheItemPoolInterface
  - `getElasticsearchClient` to get an Elasticsearch client
  - `getHttpClient` to get a Symfony Http client
- Update documentation
