### PR TITLE
extend RequestBuilder with support for HTTP HEAD requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ public static function aPutRequest(): self;
 // Creates and returns a Builder that you can use to do a PATCH request
 public static function aPatchRequest(): self;
 
+// Creates and returns a Builder that you can use to do a HEAD request
+public static function aHeadRequest(): self;
+
 // Set The Request files
 public function withFiles(array $files): self;
 

--- a/src/Test/RequestBuilder.php
+++ b/src/Test/RequestBuilder.php
@@ -42,6 +42,11 @@ final class RequestBuilder
         return new self(Request::METHOD_PATCH);
     }
 
+    public static function aHeadRequest(): self
+    {
+        return new self(Request::METHOD_HEAD);
+    }
+
     public function build(): array
     {
         return [$this->method, $this->uri, $this->parameters, $this->files, $this->server, $this->content];

--- a/tests/Integration/Test/RequestBuilderTest.php
+++ b/tests/Integration/Test/RequestBuilderTest.php
@@ -80,6 +80,20 @@ final class RequestBuilderTest extends TestCase
         self::assertNull($content);
     }
 
+    public function testBuildHeadRequest(): void
+    {
+        $request = RequestBuilder::aHeadRequest();
+
+        [$method, $uri, $parameters, $files, $server, $content] = $request->build();
+
+        self::assertEquals('HEAD', $method);
+        self::assertNull($uri);
+        self::assertEmpty($parameters);
+        self::assertEmpty($files);
+        self::assertEmpty($server);
+        self::assertNull($content);
+    }
+
     public function testBuildDeleteRequest(): void
     {
         $request = RequestBuilder::aDeleteRequest();


### PR DESCRIPTION
<!-- Describe what you are trying to achieve with this PR -->
# Description

The objective of this PR is to extend RequestBuilder with support for HTTP HEAD requests.