### PR TITLE
Fix WebTestCase restoring of Http Client fixtures

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -76,7 +76,7 @@ jobs:
         image: mysql:${{ matrix.mysql-version }}
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: false
-          MYSQL_ROOT_PASSWORD: root
+          MYSQL_ROOT_PASSWORD: ${{ secrets.CI_DATABASE_PASSWORD }}
           MYSQL_DATABASE: root
         ports:
           - 3306/tcp
@@ -132,28 +132,21 @@ jobs:
           dependency-versions: ${{ matrix.dependencies }}
           composer-options: "--prefer-stable --optimize-autoloader --no-progress --no-interaction"
 
-      - name: Get secrets
-        id: get-secrets
-        env:
-          CI_DATABASE_PASSWORD: ${{ secrets.CI_DATABASE_PASSWORD }}
-        run: |
-          echo "db_password=${CI_DATABASE_PASSWORD}" >> "$GITHUB_OUTPUT"
-
       - name: Setup storage
         run: ./tests/App/bin/setup_databases.sh
         env:
-          DEF_DATABASE_URL: mysql://root:${{ steps.get-secrets.outputs.db_password }}@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/default_db
-          PERSISTENCE_DATABASE_URL: mysql://root:${{ steps.get-secrets.outputs.db_password }}@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/persistence_db
-          MONOLITHIC_DATABASE_URL: mysql://root:${{ steps.get-secrets.outputs.db_password }}@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/monolithic_db
+          DEF_DATABASE_URL: mysql://root:${{ secrets.CI_DATABASE_PASSWORD }}@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/default_db
+          PERSISTENCE_DATABASE_URL: mysql://root:${{ secrets.CI_DATABASE_PASSWORD }}@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/persistence_db
+          MONOLITHIC_DATABASE_URL: mysql://root:${{ secrets.CI_DATABASE_PASSWORD }}@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/monolithic_db
           ELASTICSEARCH_URL: http://localhost:9200
           OPENSEARCH_URL: http://localhost:9201
           DATABASE_SERVER_VERSION: ${{ matrix.mysql-version }}
 
       - name: Run PHPUnit
         env:
-          DEF_DATABASE_URL: mysql://root:${{ steps.get-secrets.outputs.db_password }}@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/default_db
-          PERSISTENCE_DATABASE_URL: mysql://root:${{ steps.get-secrets.outputs.db_password }}@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/persistence_db
-          MONOLITHIC_DATABASE_URL: mysql://root:${{ steps.get-secrets.outputs.db_password }}@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/monolithic_db
+          DEF_DATABASE_URL: mysql://root:${{ secrets.CI_DATABASE_PASSWORD }}@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/default_db
+          PERSISTENCE_DATABASE_URL: mysql://root:${{ secrets.CI_DATABASE_PASSWORD }}@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/persistence_db
+          MONOLITHIC_DATABASE_URL: mysql://root:${{ secrets.CI_DATABASE_PASSWORD }}@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/monolithic_db
           ELASTICSEARCH_URL: http://localhost:9200
           OPENSEARCH_URL: http://localhost:9201
           DATABASE_SERVER_VERSION: ${{ matrix.mysql-version }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -189,7 +189,7 @@ jobs:
           sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' tests-junit.xml
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5.3.0
+        uses: SonarSource/sonarqube-scan-action@v5.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This bundle integrates with [kununu/data-fixtures](https://github.com/kununu/dat
 
 It also provides some utilities that makes testing easier, like a `RequestBuilder` that turns testing controllers more expressive. 
 
-If you want to see an example of what this bundle can do for you click [here](#Example).
+If you want to see an example of what this bundle can do for you click [here](docs/Test/web-test-case.md#example).
 
 ------------------------------------
 
@@ -37,7 +37,10 @@ return [
 ## Configuration
 
 Create the file `kununu_testing.yaml` inside `config/packages/test/`.
-The configuration options of the bundle heavily depend on the fixture type. Check out the [Load Fixtures](#Load-Fixtures) section where you can find more options.
+
+The configuration options of the bundle heavily depend on the fixture type.
+
+Check out the [Load Fixtures](#load-fixtures) section where you can find more options.
 
 **Tip**
 If you are using the bundle on more than one environment, for example *dev* and *test*, and the configuration options are exactly the same you can import the `kununu_testing.yaml` like bellow in order to not duplicate the configurations.
@@ -63,13 +66,14 @@ imports:
 ## Load Fixtures
 
 This bundle integrates with [kununu/data-fixtures](https://github.com/kununu/data-fixtures) allowing you to load fixtures in your tests.
+
 Currently, this bundle supports the following types of fixtures:
 
-- [Doctrine DBAL Connection Fixtures](./docs/FixturesTypes/doctrine-dbal-connection-fixtures.md)
-- [Cache Pool Fixtures](./docs/FixturesTypes/cache-pool-fixtures.md)
-- [Elasticsearch Fixtures](./docs/FixturesTypes/elasticsearch.md)
-- [OpenSearch Fixtures](./docs/FixturesTypes/opensearch.md)
-- [Symfony Http Client Fixtures](./docs/FixturesTypes/symfony-http-client.md)
+- [Doctrine DBAL Connection Fixtures](docs/FixturesTypes/doctrine-dbal-connection-fixtures.md)
+- [Cache Pool Fixtures](docs/FixturesTypes/cache-pool-fixtures.md)
+- [Elasticsearch Fixtures](docs/FixturesTypes/elasticsearch.md)
+- [OpenSearch Fixtures](docs/FixturesTypes/opensearch.md)
+- [Symfony Http Client Fixtures](docs/FixturesTypes/symfony-http-client.md)
 
 --------------------
 
@@ -85,164 +89,36 @@ See more:
 
 ------------------------------
 
-## Making a Request
+## Testing your code
 
-#### Request Builder
+To test your code, load fixtures and call your endpoints, see:
 
-This bundle provides a [Request Builder](https://github.com/kununu/testing-bundle/blob/master/src/Test/RequestBuilder.php) which makes calling an endpoint more expressive.
-
-```php
-// Creates and returns a Builder that you can use to do a GET request
-public static function aGetRequest(): self;
-
-// Creates and returns a Builder that you can use to do a POST request
-public static function aPostRequest(): self;
-
-// Creates and returns a Builder that you can use to do a DELETE request
-public static function aDeleteRequest(): self;
-
-// Creates and returns a Builder that you can use to do a PUT request
-public static function aPutRequest(): self;
-
-// Creates and returns a Builder that you can use to do a PATCH request
-public static function aPatchRequest(): self;
-
-// Creates and returns a Builder that you can use to do a HEAD request
-public static function aHeadRequest(): self;
-
-// Set The Request files
-public function withFiles(array $files): self;
-
-// Set The Request parameters
-public function withParameters(array $parameters): self;
-
-// Set The Request query string parameters
-public function withQueryParameters(array $queryParameters): self;
-
-// Change The request method
-public function withMethod(string $method): self;
-
-// Set the URI to fetch
-public function withUri(string $uri): self;
-
-// Set the content of the request as an array that internally is transformed to a json and provided as the raw body data
-public function withContent(array $content): self;
-
-// Set the Raw body data
-public function withRawContent(string $content): self;
-
-// Sets an HTTP_AUTHORIZATION header with the value of "Bearer $token"
-public function withAuthorization(string $token): self;
-
-// Sets a header. 
-// In converts any header name to uppercase and prepends "HTTP_" if the header name does not contain it
-public function withHeader(string $headerName, string $headerValue): self;
-
-// Sets a server parameter (HTTP headers are referenced with an HTTP_ prefix as PHP does)
-public function withServerParameter(string $parameterName, string $parameterValue): self;
-```
-
-#### WebTestCase
-
-This bundle exposes the [WebTestCase](https://github.com/kununu/testing-bundle/blob/master/src/Test/WebTestCase.php) that you can extend which exposes a method that helps you to test your controllers without having to care about creating the kernel. 
-
-This class also allows you load fixtures in your tests.
-
-```php
-final protected function doRequest(RequestBuilder $builder): Symfony\Component\HttpFoundation\Response
-```
-
-Internally this method calls the Symfony client with:
-
-```php
-$client->request($builder->method, $builder->uri, $builder->parameters, $builder->files, $builder->server, $builder->content);
-```
-
---------------------------
-
-## Example
-
-Let's imagine that you have a route named *company_create* which is protected (A valid access token needs to be provided) and expects a json to be provided in the body of the request with the data required to create a new company.
-
-```yaml
-# routes.yaml
-company_create:
-  path:       /companies
-  controller: App\Controller\CompaniesController::createAction
-  methods:    [POST]
-```
-
-Using concepts provided by this bundle, like *Loading Fixtures*, the *RequestBuilder* and the *WebTestCase* our test could like:
-
-```php
-<?php
-declare(strict_types=1);
-
-namespace App\Tests\Integration\Controller;
-
-use App\Tests\Integration\Controller\DataFixtures\MySQL\CreateCompanyDataFixtures;
-use Kununu\TestingBundle\Test\Options\DbOptions;
-use Kununu\TestingBundle\Test\RequestBuilder;
-use Kununu\TestingBundle\Test\WebTestCase;
-use Symfony\Component\HttpFoundation\Response;
-
-final class CompaniesControllerTest extends WebTestCase
-{
-    public function testCreateCompany(): void
-    {
-        $this->loadDbFixtures('your_doctrine_connection_name', DbOptions::create(), CreateCompanyDataFixtures::class);
-
-        $data = [
-            'name'        => 'kununu GmbH',
-            'location'    => [
-                'city'         => 'Wien',
-                'country_code' => 'at',
-            ],
-        ];
-
-        $response = $this->doRequest(
-            RequestBuilder::aPostRequest()
-                ->withUri('/companies')
-                ->withContent($data)
-                ->withAuthorization('eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6IjYyZDVkNzc5NmQxOTk')
-                ->withServerParameter('REMOTE_ADDR', '127.0.0.1')
-        );
-
-        self::assertNotNull($response->getContent());
-        self::assertEquals(Response::HTTP_CREATED, $response->getStatusCode());
-
-        $json = $response->getContent();
-        self::assertJson($json);
-
-        $company = json_decode($json, true);
-
-        self::assertSame($data['name'], $company['name']);
-        self::assertSame($data['location']['city'], $company['location']['city']);
-        self::assertSame($data['location']['country_code'], $company['location']['country_code']);
-    }
-}
-```
+- [FixtureAwareTextCase](docs/Test/fixtures-aware-test-case.md)
+- [WebTestCase](docs/Test/web-test-case.md)
+- [Request Builder](docs/Test/request-builder.md)
 
 ------------------------------
 
-## Contribute
-
-If you are interested in contributing read our [contributing guidelines](CONTRIBUTING.md).
-
-------------------------------
-
-## Tests
+## Testing the bundle
 
 This repository takes advantages of GitHub actions to run tests when a commit is performed to a branch.
 
 If you want to run the integration tests on your local machine you will need:
+
 - *pdo_mysql* extension
 - MySQL server
 - Elasticsearch cluster
 - OpenSearch cluster
 
 In your local environment to get everything ready for you, run `./tests/setupLocalTests.sh` and follow the instructions.
+
 Then you can run the tests: `vendor/bin/phpunit`.
+
+------------------------------
+
+## Contribute
+
+If you are interested in contributing read our [contributing guidelines](CONTRIBUTING.md).
 
 ------------------------------
 

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -15,6 +15,7 @@ return (new Configuration())
             'symfony/console',
             'symfony/error-handler',
             'symfony/http-client-contracts',
+            'symfony/routing',
         ],
         [ErrorType::SHADOW_DEPENDENCY]
     )

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
   "require": {
     "php": ">=8.3",
     "ext-filter": "*",
+    "kununu/collections": "^6.4",
     "kununu/data-fixtures": "^13.0",
     "symfony/config": "^6.4",
     "symfony/dependency-injection": "^6.4",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "ext-json": "*",
     "ext-pdo": "*",
     "doctrine/dbal": "^3.8",
-    "doctrine/doctrine-bundle": "2.15.*",
+    "doctrine/doctrine-bundle": "~2.15.0",
     "doctrine/doctrine-migrations-bundle": "^3.3",
     "doctrine/orm": "^3.0",
     "elasticsearch/elasticsearch": "^7.10",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "ext-json": "*",
     "ext-pdo": "*",
     "doctrine/dbal": "^3.8",
-    "doctrine/doctrine-bundle": "^2.7",
+    "doctrine/doctrine-bundle": "2.15.*",
     "doctrine/doctrine-migrations-bundle": "^3.3",
     "doctrine/orm": "^3.0",
     "elasticsearch/elasticsearch": "^7.10",

--- a/docs/FixturesTypes/cache-pool-fixtures.md
+++ b/docs/FixturesTypes/cache-pool-fixtures.md
@@ -150,3 +150,7 @@ kununu_testing:
           - 'Kununu\TestingBundle\Tests\App\Fixtures\CachePool\CachePoolFixture1'
           - 'Kununu\TestingBundle\Tests\App\Fixtures\CachePool\CachePoolFixture2'
 ```
+
+---
+
+[Back to Index](../../README.md)

--- a/docs/FixturesTypes/doctrine-dbal-connection-fixtures.md
+++ b/docs/FixturesTypes/doctrine-dbal-connection-fixtures.md
@@ -229,3 +229,7 @@ kununu_testing:
       excluded_tables: # List of tables to exclude from being purged
         - table_to_exclude_from_purge
 ```
+
+---
+
+[Back to Index](../../README.md)

--- a/docs/FixturesTypes/elasticsearch.md
+++ b/docs/FixturesTypes/elasticsearch.md
@@ -147,3 +147,7 @@ kununu_testing:
       service: 'Kununu\TestingBundle\Tests\App\Elasticsearch' # Service Id of an instance of Elasticsearch\Client 
       index_name: 'my_index_name' # name of your index
 ```
+
+---
+
+[Back to Index](../../README.md)

--- a/docs/FixturesTypes/opensearch.md
+++ b/docs/FixturesTypes/opensearch.md
@@ -147,3 +147,7 @@ kununu_testing:
       service: 'Kununu\TestingBundle\Tests\App\OpenSearch' # Service Id of an instance of OpenSearch\Client 
       index_name: 'my_index_name' # name of your index
 ```
+
+---
+
+[Back to Index](../../README.md)

--- a/docs/FixturesTypes/options.md
+++ b/docs/FixturesTypes/options.md
@@ -99,3 +99,7 @@ $options = DbOptions::create()->withoutTransactional();
 // your desired configuration
 $options = DbOptions::create()->withoutClear()->withAppend()->withoutTransactional();
 ```
+
+---
+
+[Back to Index](../../README.md)

--- a/docs/FixturesTypes/symfony-http-client.md
+++ b/docs/FixturesTypes/symfony-http-client.md
@@ -122,3 +122,7 @@ framework:
 ```
 
 To disable Symfony Framework bundle creating its own Http clients.
+
+---
+
+[Back to Index](../../README.md)

--- a/docs/SchemaCopier/schema-copier.md
+++ b/docs/SchemaCopier/schema-copier.md
@@ -25,3 +25,7 @@ php bin/console kununu_testing:connections:schema:copy --from SOURCE --to DESTIN
 Be aware that this command will **DESTROY** all tables and views (including data) on your *DESTINATION* database schema!
 
 Please take caution when using it.
+
+---
+
+[Back to Index](../../README.md)

--- a/docs/Test/fixtures-aware-test-case.md
+++ b/docs/Test/fixtures-aware-test-case.md
@@ -1,0 +1,75 @@
+# FixturesAwareTestCase
+
+The main idea of using the bundle is to be able to configure and use data fixtures in your test methods. This test case provides methods that will allow you precisely that.
+
+See [Load Fixtures](../../README.md#load-fixtures) for a list of fixtures types available and check each fixture documentation page to learn how to configure and use them and also get examples.
+
+## Clear Fixtures methods
+
+These are the methods available to clear loaded fixtures:
+
+```php
+final protected function clearCachePoolFixtures(string $cachePoolServiceId): static;
+
+final protected function clearDbFixtures(string $connectionName, DbOptionsInterface $options): static;
+
+final protected function clearElasticsearchFixtures(string $alias): static
+
+final protected function clearHttpClientFixtures(string $httpClientServiceId): static;
+
+final protected function clearOpenSearchFixtures(string $alias): static;
+```
+
+## Get Fixtures methods
+
+These are the methods available to get already loaded fixtures:
+
+```php
+final protected function getCachePoolFixtures(string $cachePoolServiceId): array;
+
+final protected function getDbFixtures(string $connectionName, DbOptionsInterface $options): array;
+
+final protected function getElasticsearchFixtures(string $alias): array;
+
+final protected function getHttpClientFixtures(string $httpClientServiceId): array;
+
+final protected function getOpenSearchFixtures(string $alias): array;
+```
+
+## Load Fixtures methods
+
+These are the methods available to load fixtures:
+
+```php
+final protected function loadCachePoolFixtures(string $cachePoolServiceId, OptionsInterface $options, string ...$classNames): void;
+
+final protected function loadDbFixtures(string $connectionName, DbOptionsInterface $options, string ...$classNames): void;
+    
+final protected function loadElasticsearchFixtures(string $alias, OptionsInterface $options, string ...$classNames): void;
+
+final protected function loadHttpClientFixtures(string $httpClientServiceId, OptionsInterface $options, string ...$className): void;
+
+final protected function loadOpenSearchFixtures(string $alias, OptionsInterface $options, string ...$className): void;
+```
+
+## Register Initializable Fixtures methods
+
+These are the methods available to register initializable fixtures:
+
+```php
+final protected function registerInitializableFixtureForCachePool(string $cachePoolServiceId, string $className, mixed ...$args): void
+
+final protected function registerInitializableFixtureForDb(string $connectionName, string $className, mixed ...$args): void;
+
+final protected function registerInitializableFixtureForElasticsearch(string $alias, string $className, mixed ...$args): void;
+
+final protected function registerInitializableFixtureForHttpClient(string $httpClientServiceId, string $className, mixed ...$args): void;
+
+final protected function registerInitializableFixtureForNonTransactionalDb(string $connectionName, string $className, mixed ...$args): void;
+
+final protected function registerInitializableFixtureForOpenSearch(string $alias, string $className, mixed ...$args): void
+```
+
+---
+
+[Back to Index](../../README.md)

--- a/docs/Test/request-builder.md
+++ b/docs/Test/request-builder.md
@@ -1,0 +1,94 @@
+# Request Builder
+
+This bundle provides a [Request Builder](../../src/Test/RequestBuilder.php) which makes calling an endpoint more expressive.
+
+```php
+//----------------------------------------------------------------------------------------------------------------------
+
+// Creates and returns a builder that you can use to do a CONNECT request
+public static function aConnectRequest(): self;
+
+// Creates and returns a builder that you can use to do a DELETE request
+public static function aDeleteRequest(): self;
+
+// Creates and returns a builder that you can use to do a GET request
+public static function aGetRequest(): self;
+
+// Creates and returns a builder that you can use to do a HEAD request
+public static function aHeadRequest(): self;
+
+// Creates and returns a builder that you can use to do a OPTIONS request
+public static function aOptionsRequest(): self
+
+// Creates and returns a builder that you can use to do a PATCH request
+public static function aPatchRequest(): self;
+
+// Creates and returns a builder that you can use to do a POST request
+public static function aPostRequest(): self;
+
+// Creates and returns a builder that you can use to do a PURGE request
+public static function aPurgeRequest(): self
+
+// Creates and returns a builder that you can use to do a PUT request
+public static function aPutRequest(): self;
+
+// Creates and returns a builder that you can use to do a TRACE request
+public static function aTraceRequest(): self;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// Return an array used to build a request
+public function build(): array
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// Set an HTTP_AUTHORIZATION header with the value of "Bearer $token"
+public function withAuthorization(string $token): self;
+
+// Set the content of the request as an array that internally is transformed to JSON and provided as the raw body data
+public function withContent(array $content): self;
+
+// Set the request files
+public function withFiles(array $files): self;
+
+// Set a request header. In converts any header name to uppercase and prepends "HTTP_" if the header name does
+// not contain it
+public function withHeader(string $headerName, string $headerValue): self;
+
+// Set the request method
+public function withMethod(string $method): self;
+
+// Set the request parameters
+public function withParameters(array $parameters): self;
+
+// Set the request query string parameters
+public function withQueryParameters(array $queryParameters): self;
+
+// Set the request raw body data
+public function withRawContent(string $content): self;
+
+// Set a request server parameter (HTTP headers are referenced with an HTTP_ prefix as PHP does)
+public function withServerParameter(string $parameterName, string $parameterValue): self;
+
+// Set the request URI
+public function withUri(string $uri): self;
+```
+
+## Example
+
+```php
+<?php
+
+use Kununu\TestingBundle\Test\RequestBuilder;
+
+$requestBuilder = RequestBuilder::aGetRequest()
+    ->withUri('/find-company')
+    ->withQueryParameters(['id' => 10, 'name' => 'kununu'])
+    ->withAuthorization('eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6IjYyZDVkNzc5NmQxOTk')
+    ->withServerParameter('REMOTE_ADDR', '127.0.0.1')
+    ->withHeader('x-extra-header', 'my-value');
+```
+
+---
+
+[Back to Index](../../README.md)

--- a/docs/Test/web-test-case.md
+++ b/docs/Test/web-test-case.md
@@ -1,0 +1,94 @@
+# WebTestCase
+
+As an extension to the [FixturesAwareTestCase](fixtures-aware-test-case.md), this bundle offers the [WebTestCase](../../src/Test/WebTestCase.php). 
+
+That abstract test case exposes a method that helps you to test your controllers without having to care about creating the kernel.
+
+```php
+final protected function doRequest(RequestBuilder $builder): Symfony\Component\HttpFoundation\Response
+```
+
+Internally this method calls the Symfony client with:
+
+```php
+$client->request($builder->method, $builder->uri, $builder->parameters, $builder->files, $builder->server, $builder->content);
+```
+
+And the parameters values are the ones returned by the [RequestBuilder](request-builder.md) `build` method.
+
+--------------------------
+
+## Example
+
+Let's imagine that you have a route named *company_create*.
+
+- That endpoint is protected (a valid access token needs to be provided)
+- It a JSON to be provided in the body of the request with the data required to create a new company
+
+```yaml
+# routes.yaml
+company_create:
+  path:       /companies
+  controller: App\Controller\CompaniesController::createAction
+  methods:    [POST]
+```
+
+Using concepts provided by this bundle, like [Loading Fixtures](fixtures-aware-test-case.md), the [RequestBuilder](request-builder.md) and the [WebTestCase](#webtestcase) our test could like:
+
+```php
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Controller;
+
+use App\Tests\Integration\Controller\DataFixtures\MySQL\CreateCompanyDataFixtures;
+use Kununu\TestingBundle\Test\Options\DbOptions;
+use Kununu\TestingBundle\Test\RequestBuilder;
+use Kununu\TestingBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CompaniesControllerTest extends WebTestCase
+{
+    public function testCreateCompany(): void
+    {
+        // Let's load a database fixture
+        $this->loadDbFixtures('your_doctrine_connection_name', DbOptions::create(), CreateCompanyDataFixtures::class);
+
+        $data = [
+            'name'        => 'kununu GmbH',
+            'location'    => [
+                'city'         => 'Wien',
+                'country_code' => 'at',
+            ],
+        ];
+
+        // Let's use WebTestCase::doRequest to execute the request
+        $response = $this->doRequest(
+            // And build the request with the RequestBuilder
+            RequestBuilder::aPostRequest()
+                ->withUri('/companies')
+                ->withContent($data)
+                ->withAuthorization('eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6IjYyZDVkNzc5NmQxOTk')
+                ->withServerParameter('REMOTE_ADDR', '127.0.0.1')
+        );
+
+        // Now we can do our assertions about the Response returned from the controller
+
+        self::assertNotNull($response->getContent());
+        self::assertEquals(Response::HTTP_CREATED, $response->getStatusCode());
+
+        $json = $response->getContent();
+        self::assertJson($json);
+
+        $company = json_decode($json, true);
+
+        self::assertSame($data['name'], $company['name']);
+        self::assertSame($data['location']['city'], $company['location']['city']);
+        self::assertSame($data['location']['country_code'], $company['location']['country_code']);
+    }
+}
+```
+
+---
+
+[Back to Index](../../README.md)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,7 +25,7 @@
   <logging>
     <junit outputFile="tests/.results/tests-junit.xml"/>
   </logging>
-  <source>
+  <source ignoreIndirectDeprecations="true" restrictNotices="true" restrictWarnings="true">
     <include>
       <directory>src</directory>
     </include>

--- a/src/Test/RequestBuilder.php
+++ b/src/Test/RequestBuilder.php
@@ -23,19 +23,14 @@ final class RequestBuilder
         return new self(Request::METHOD_GET);
     }
 
-    public static function aPostRequest(): self
+    public static function aHeadRequest(): self
     {
-        return new self(Request::METHOD_POST);
+        return new self(Request::METHOD_HEAD);
     }
 
-    public static function aDeleteRequest(): self
+    public static function aOptionsRequest(): self
     {
-        return new self(Request::METHOD_DELETE);
-    }
-
-    public static function aPutRequest(): self
-    {
-        return new self(Request::METHOD_PUT);
+        return new self(Request::METHOD_OPTIONS);
     }
 
     public static function aPatchRequest(): self
@@ -43,19 +38,64 @@ final class RequestBuilder
         return new self(Request::METHOD_PATCH);
     }
 
-    public static function aHeadRequest(): self
+    public static function aPostRequest(): self
     {
-        return new self(Request::METHOD_HEAD);
+        return new self(Request::METHOD_POST);
+    }
+
+    public static function aPurgeRequest(): self
+    {
+        return new self(Request::METHOD_PURGE);
+    }
+
+    public static function aPutRequest(): self
+    {
+        return new self(Request::METHOD_PUT);
+    }
+
+    public static function aTraceRequest(): self
+    {
+        return new self(Request::METHOD_TRACE);
     }
 
     public function build(): array
     {
-        return [$this->method, $this->getUriWithQueryStringParameters(), $this->parameters, $this->files, $this->server, $this->content];
+        return [$this->method, $this->buildUri(), $this->parameters, $this->files, $this->server, $this->content];
+    }
+
+    public function withAuthorization(string $token): self
+    {
+        return $this->withHeader('HTTP_AUTHORIZATION', sprintf('Bearer %s', $token));
+    }
+
+    public function withContent(array $content): self
+    {
+        return $this->withRawContent(json_encode($content));
     }
 
     public function withFiles(array $files): self
     {
         $this->files = $files;
+
+        return $this;
+    }
+
+    public function withHeader(string $headerName, string $headerValue): self
+    {
+        $headerName = strtoupper($headerName);
+
+        if (!str_starts_with($headerName, 'HTTP_')) {
+            $headerName = sprintf('HTTP_%s', $headerName);
+        }
+
+        $this->server[$headerName] = $headerValue;
+
+        return $this;
+    }
+
+    public function withMethod(string $method): self
+    {
+        $this->method = $method;
 
         return $this;
     }
@@ -74,46 +114,9 @@ final class RequestBuilder
         return $this;
     }
 
-    public function withMethod(string $method): self
-    {
-        $this->method = $method;
-
-        return $this;
-    }
-
-    public function withUri(string $uri): self
-    {
-        $this->uri = $uri;
-
-        return $this;
-    }
-
-    public function withContent(array $content): self
-    {
-        return $this->withRawContent(json_encode($content));
-    }
-
     public function withRawContent(string $content): self
     {
         $this->content = $content;
-
-        return $this;
-    }
-
-    public function withAuthorization(string $token): self
-    {
-        return $this->withHeader('HTTP_AUTHORIZATION', sprintf('Bearer %s', $token));
-    }
-
-    public function withHeader(string $headerName, string $headerValue): self
-    {
-        $headerName = strtoupper($headerName);
-
-        if (!str_starts_with($headerName, 'HTTP_')) {
-            $headerName = sprintf('HTTP_%s', $headerName);
-        }
-
-        $this->server[$headerName] = $headerValue;
 
         return $this;
     }
@@ -125,7 +128,24 @@ final class RequestBuilder
         return $this;
     }
 
-    private function getUriWithQueryStringParameters(): ?string
+    public static function aConnectRequest(): self
+    {
+        return new self(Request::METHOD_CONNECT);
+    }
+
+    public static function aDeleteRequest(): self
+    {
+        return new self(Request::METHOD_DELETE);
+    }
+
+    public function withUri(string $uri): self
+    {
+        $this->uri = $uri;
+
+        return $this;
+    }
+
+    private function buildUri(): ?string
     {
         return empty($this->queryParameters)
             ? $this->uri

--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -48,7 +48,9 @@ abstract class WebTestCase extends FixturesAwareTestCase
                 Options::create()->withAppend()->withoutClear(),
                 ...$fixtures
             ),
+            // @codeCoverageIgnoreStart
             default             => null,
+            // @codeCoverageIgnoreEnd
         };
     }
 }

--- a/tests/App/Controller/AppController.php
+++ b/tests/App/Controller/AppController.php
@@ -4,11 +4,32 @@ declare(strict_types=1);
 namespace Kununu\TestingBundle\Tests\App\Controller;
 
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class AppController
+#[Route(
+    path: 'response/{id}',
+    name: 'app.response',
+    requirements: ['id' => '\d+'],
+    defaults: ['id' => null],
+    methods: [Request::METHOD_GET],
+)]
+final readonly class AppController
 {
-    public function response(): JsonResponse
+    public function __construct(private HttpClientInterface $client)
     {
-        return new JsonResponse(['key' => 'value']);
+    }
+
+    public function __invoke(?int $id): JsonResponse
+    {
+        if ($id) {
+            $response = $this->client->request('GET', sprintf('https://my-external-service.fake/external/%d', $id));
+            $value = json_decode($response->getContent(), true)['value'];
+        } else {
+            $value = 'value';
+        }
+
+        return new JsonResponse(['key' => $value]);
     }
 }

--- a/tests/App/Fixtures/HttpClient/Responses/HttpClientFixture2/responses.php
+++ b/tests/App/Fixtures/HttpClient/Responses/HttpClientFixture2/responses.php
@@ -14,7 +14,6 @@ return [
     "age": 39,
     "newsletter": true
 }
-JSON
-        ,
+JSON,
     ],
 ];

--- a/tests/App/config/packages/framework.yaml
+++ b/tests/App/config/packages/framework.yaml
@@ -1,4 +1,6 @@
 framework:
+  http_client:
+    enabled: false
   http_method_override: false
   handle_all_throwables: true
   session:

--- a/tests/App/config/routes.php
+++ b/tests/App/config/routes.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return static function(RoutingConfigurator $routingConfigurator): void {
+    $routingConfigurator
+        ->import(
+            [
+                'path'      => __DIR__ . '/../Controller',
+                'namespace' => 'Kununu\TestingBundle\Tests\App\Controller',
+            ],
+            'attribute'
+        )
+        ->prefix('/app');
+};

--- a/tests/App/config/routes.yaml
+++ b/tests/App/config/routes.yaml
@@ -1,3 +1,0 @@
-app_response:
-  path: /app/response
-  controller: Kununu\TestingBundle\Tests\App\Controller\AppController::response

--- a/tests/App/config/services.yaml
+++ b/tests/App/config/services.yaml
@@ -22,3 +22,10 @@ services:
   http_client:
     class: Kununu\DataFixtures\Tools\HttpClient
     public: true
+
+  Symfony\Contracts\HttpClient\HttpClientInterface: '@http_client'
+
+  Kununu\TestingBundle\Tests\App\Controller\AppController:
+    public: true
+    arguments:
+      $client: '@http_client'

--- a/tests/Integration/Test/AbstractTestCaseTest.php
+++ b/tests/Integration/Test/AbstractTestCaseTest.php
@@ -27,6 +27,7 @@ final class AbstractTestCaseTest extends AbstractTestCase
         self::assertInstanceOf(OpenClientFactory::class, $this->getServiceFromContainer(self::OPEN_FACTORY));
 
         self::assertFalse($this->getFixturesContainer()->has(self::NON_EXISTING_SERVICE));
+
         $this->expectException(ServiceNotFoundException::class);
 
         $this->getServiceFromContainer(self::NON_EXISTING_SERVICE);

--- a/tests/Integration/Test/DataFixtures/Responses/WebTestCaseFixture1/responses.php
+++ b/tests/Integration/Test/DataFixtures/Responses/WebTestCaseFixture1/responses.php
@@ -2,11 +2,11 @@
 declare(strict_types=1);
 
 return [
-    // HTTP GET to check reload after kernel shutdown
     [
-        'url'    => '/test-http-fixtures',
+        'url'    => 'https://my-external-service.fake/external/1',
         'body'   => <<<'JSON'
 {
+  "value": 1
 }
 JSON,
     ],

--- a/tests/Integration/Test/DataFixtures/Responses/WebTestCaseFixture2/responses.php
+++ b/tests/Integration/Test/DataFixtures/Responses/WebTestCaseFixture2/responses.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+return [
+    [
+        'url'    => 'https://my-external-service.fake/external/2',
+        'body'   => <<<'JSON'
+{
+  "value": 2
+}
+JSON,
+    ],
+];

--- a/tests/Integration/Test/DataFixtures/WebTestCaseFixture1.php
+++ b/tests/Integration/Test/DataFixtures/WebTestCaseFixture1.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Kununu\TestingBundle\Tests\Integration\Test\DataFixtures;
+
+use Kununu\DataFixtures\Adapter\DirectoryLoader\HttpClientArrayDirectoryFixture;
+
+final class WebTestCaseFixture1 extends HttpClientArrayDirectoryFixture
+{
+}

--- a/tests/Integration/Test/DataFixtures/WebTestCaseFixture2.php
+++ b/tests/Integration/Test/DataFixtures/WebTestCaseFixture2.php
@@ -5,6 +5,6 @@ namespace Kununu\TestingBundle\Tests\Integration\Test\DataFixtures;
 
 use Kununu\DataFixtures\Adapter\DirectoryLoader\HttpClientArrayDirectoryFixture;
 
-final class WebTestCaseFixture extends HttpClientArrayDirectoryFixture
+final class WebTestCaseFixture2 extends HttpClientArrayDirectoryFixture
 {
 }

--- a/tests/Integration/Test/FixturesAwareTestCaseHttpClientTest.php
+++ b/tests/Integration/Test/FixturesAwareTestCaseHttpClientTest.php
@@ -53,8 +53,7 @@ final class FixturesAwareTestCaseHttpClientTest extends FixturesAwareTestCase
     "age": 39,
     "newsletter": true
 }
-JSON
-            ,
+JSON,
             $response->getContent()
         );
     }
@@ -88,8 +87,7 @@ JSON
     "age": 39,
     "newsletter": true
 }
-JSON
-            ,
+JSON,
             $response->getContent()
         );
     }

--- a/tests/Integration/Test/WebTestCaseTest.php
+++ b/tests/Integration/Test/WebTestCaseTest.php
@@ -6,27 +6,69 @@ namespace Kununu\TestingBundle\Tests\Integration\Test;
 use Kununu\TestingBundle\Test\Options\Options;
 use Kununu\TestingBundle\Test\RequestBuilder;
 use Kununu\TestingBundle\Test\WebTestCase;
-use Kununu\TestingBundle\Tests\Integration\Test\DataFixtures\WebTestCaseFixture;
+use Kununu\TestingBundle\Tests\Integration\Test\DataFixtures\WebTestCaseFixture1;
+use Kununu\TestingBundle\Tests\Integration\Test\DataFixtures\WebTestCaseFixture2;
+use Symfony\Component\HttpFoundation\Response;
 
 final class WebTestCaseTest extends WebTestCase
 {
-    public function testDoRequest(): void
-    {
-        $response = $this->doRequest(
-            RequestBuilder::aGetRequest()->withUri('/app/response')
-        );
+    private const string HTTP_CLIENT = 'http_client';
 
-        self::assertEquals('{"key":"value"}', $response->getContent());
+    public function testNoFixturesLoaded(): void
+    {
+        $response = $this->executeRequest();
+
+        self::assertResponse($response);
+        self::assertEmpty($this->getCurrentFixtures());
     }
 
-    public function testThatHttpFixturesGetLoaded(): void
+    public function testFixturesLoadedAndRestored(): void
     {
-        $this->loadHttpClientFixtures('http_client', Options::create(), WebTestCaseFixture::class);
-
-        $this->doRequest(
-            RequestBuilder::aGetRequest()->withUri('/app/response')
+        $this->loadHttpClientFixtures(
+            self::HTTP_CLIENT,
+            Options::create(),
+            WebTestCaseFixture1::class,
+            WebTestCaseFixture2::class
         );
 
-        self::assertNotEmpty($this->getHttpClientFixtures('http_client'));
+        $this->assertLoadedFixtures();
+
+        // Do a bunch of requests, all of them should restore the loaded http client fixtures
+        // and those fixtures should respond if any call is made to the (fake) http client inside the code
+        // handled by the request (in this case our controller can call a putative external service with
+        // the http client)
+        foreach ([1, null, 1, 1, 2, 2, 1, null] as $id) {
+            $response = $this->executeRequest($id);
+
+            self::assertResponse($response, $id);
+            $this->assertLoadedFixtures();
+        }
+    }
+
+    private static function assertResponse(Response $response, ?int $id = null): void
+    {
+        self::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        self::assertEquals(sprintf('{"key":%s}', $id ?? '"value"'), $response->getContent());
+    }
+
+    private function assertLoadedFixtures(): void
+    {
+        self::assertEquals(
+            [WebTestCaseFixture1::class, WebTestCaseFixture2::class],
+            array_keys($this->getCurrentFixtures())
+        );
+    }
+
+    private function getCurrentFixtures(): array
+    {
+        return $this->getHttpClientFixtures(self::HTTP_CLIENT);
+    }
+
+    private function executeRequest(?int $id = null): Response
+    {
+        $request = RequestBuilder::aGetRequest()
+            ->withUri(sprintf('/app/response%s', $id === null ? '' : sprintf('/%d', $id)));
+
+        return $this->doRequest($request);
     }
 }

--- a/tests/Unit/Test/RequestBuilderTest.php
+++ b/tests/Unit/Test/RequestBuilderTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Kununu\TestingBundle\Tests\Unit\Test;
 
+use BadMethodCallException;
 use Kununu\TestingBundle\Test\RequestBuilder;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -301,5 +302,14 @@ final class RequestBuilderTest extends TestCase
         [, , , , $server] = $request->build();
 
         self::assertEquals(['REMOTE_ADDR' => '127.0.0.1', 'HTTP_ACCEPT' => 'application/json'], $server);
+    }
+
+    public function testBadStaticMethodCall(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Invalid static method "invalidMethod" called');
+
+        // @phpstan-ignore staticMethod.notFound
+        RequestBuilder::invalidMethod();
     }
 }

--- a/tests/Unit/Test/RequestBuilderTest.php
+++ b/tests/Unit/Test/RequestBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Kununu\TestingBundle\Tests\Integration\Test;
+namespace Kununu\TestingBundle\Tests\Unit\Test;
 
 use Kununu\TestingBundle\Test\RequestBuilder;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -150,6 +150,62 @@ final class RequestBuilderTest extends TestCase
 
         self::assertEquals('DELETE', $method);
         self::assertEquals('/a/uri/path/?param1=value1&param_2=2', $uri);
+        self::assertEmpty($parameters);
+        self::assertEmpty($files);
+        self::assertEmpty($server);
+        self::assertNull($content);
+    }
+
+    public function testBuildConnectRequest(): void
+    {
+        $request = RequestBuilder::aConnectRequest();
+
+        [$method, $uri, $parameters, $files, $server, $content] = $request->build();
+
+        self::assertEquals('CONNECT', $method);
+        self::assertNull($uri);
+        self::assertEmpty($parameters);
+        self::assertEmpty($files);
+        self::assertEmpty($server);
+        self::assertNull($content);
+    }
+
+    public function testBuildOptionsRequest(): void
+    {
+        $request = RequestBuilder::aOptionsRequest();
+
+        [$method, $uri, $parameters, $files, $server, $content] = $request->build();
+
+        self::assertEquals('OPTIONS', $method);
+        self::assertNull($uri);
+        self::assertEmpty($parameters);
+        self::assertEmpty($files);
+        self::assertEmpty($server);
+        self::assertNull($content);
+    }
+
+    public function testBuildPurgeRequest(): void
+    {
+        $request = RequestBuilder::aPurgeRequest();
+
+        [$method, $uri, $parameters, $files, $server, $content] = $request->build();
+
+        self::assertEquals('PURGE', $method);
+        self::assertNull($uri);
+        self::assertEmpty($parameters);
+        self::assertEmpty($files);
+        self::assertEmpty($server);
+        self::assertNull($content);
+    }
+
+    public function testBuildTraceRequest(): void
+    {
+        $request = RequestBuilder::aTraceRequest();
+
+        [$method, $uri, $parameters, $files, $server, $content] = $request->build();
+
+        self::assertEquals('TRACE', $method);
+        self::assertNull($uri);
         self::assertEmpty($parameters);
         self::assertEmpty($files);
         self::assertEmpty($server);


### PR DESCRIPTION
# Description

The objective of this PR is to fix the way Http Client fixtures are restored after calling the `doRequest` on `WebTestCase`

## Details
- `doRequest` method will no longer have a 3rd optional `Options` value (breaking change)
   - Instead of using this value when restoring the fixtures, the bundle will always use `Options::create()->withoutClear()->withAppend()` as the options for each restored Http Client fixture


