### PR TITLE
Bump minimum PHP version to 8.4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.4
           coverage: none
           extensions: filter
-          tools: composer-dependency-analyser, composer-normalize, composer-require-checker
+          tools: composer-dependency-analyser, composer-normalize, composer-require-checker, cs2pr
 
       - name: Install Composer Dependencies
         uses: ramsey/composer-install@v3
@@ -47,20 +47,27 @@ jobs:
       - name: Run PHP CS Fixer
         run: vendor/bin/php-cs-fixer check --using-cache=no --config vendor/kununu/code-tools/php-cs-fixer.php src/ tests/
 
+      - name: Run PHP_CodeSniffer
+        id: php-code-sniffer
+        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml --colors src/ tests/
+
+      - name: Show PHP_CodeSniffer results in PR
+        if: ${{ always() && steps.php-code-sniffer.outcome == 'failure' }}
+        run: cs2pr ./phpcs-report.xml
+
       - name: Run Rector
         run: vendor/bin/rector process --ansi --dry-run --config rector-ci.php src/ tests/
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse --ansi
 
-  build:
+  tests:
     needs: checks
-    name: PHPUnit
+    name: Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
         php-version:
-          - 8.3
           - 8.4
         mysql-version:
           - 8.0
@@ -175,8 +182,9 @@ jobs:
           include-hidden-files: true
           path: tests/.results/
 
-  sonarcloud:
-    needs: build
+  code_analysis:
+    needs: tests
+    name: Code Analysis
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -185,7 +193,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: build-8.3-highest-coverage
+          name: tests-8.4-highest-coverage
           path: tests/.results/
 
       - name: Fix Code Coverage Paths

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     }
   ],
   "require": {
-    "php": ">=8.3",
+    "php": ">=8.4",
     "ext-filter": "*",
-    "kununu/collections": "^6.4",
-    "kununu/data-fixtures": "^14.0",
+    "kununu/collections": "^7.0",
+    "kununu/data-fixtures": "^15.0",
     "symfony/config": "^6.4 || ^7.4",
     "symfony/dependency-injection": "^6.4 || ^7.4",
     "symfony/framework-bundle": "^6.4 || ^7.4",
@@ -37,7 +37,7 @@
     "doctrine/doctrine-migrations-bundle": "^3.7",
     "doctrine/orm": "^3.6",
     "elasticsearch/elasticsearch": "^7.10",
-    "kununu/code-tools": "^3.1",
+    "kununu/code-tools": "^4.0",
     "matthiasnoback/symfony-dependency-injection-test": "^6.2",
     "nyholm/psr7": "^1.8",
     "opensearch-project/opensearch-php": "^2.5",
@@ -98,6 +98,7 @@
     "phpstan": "phpstan",
     "rector": "rector process --dry-run --config rector-ci.php src/ tests/",
     "rector-fix": "rector process --config rector-ci.php src/ tests/",
+    "sniffer": "phpcs",
     "test": [
       "rm -rf tests/App/var/*",
       "tests/App/bin/setup_databases.sh test",
@@ -118,6 +119,7 @@
     "phpstan": "Run PHPStan",
     "rector": "Run Rector in dry-run mode with CI rules",
     "rector-fix": "Run Rector in fix mode with CI rules",
+    "sniffer": "Run PHP_CodeSniffer",
     "test": "Run all tests",
     "test-coverage": "Run all tests with coverage report",
     "unit": "Run all unit tests",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="code-tools"
+         xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/refs/heads/master/phpcs.xsd">
+  <config name="installed_paths" value="vendor/kununu/code-tools"/>
+
+  <arg name="colors"/>
+  <arg name="parallel" value="75"/>
+  <arg value="p"/>
+  <arg value="n"/>
+
+  <file>src/</file>
+  <file>tests/</file>
+
+  <!-- Include all Kununu rules -->
+  <rule ref="Kununu"/>
+
+  <!-- Customize Rules according to project needs -->
+  <rule ref="Kununu.Files.LineLength">
+    <properties>
+      <property name="ignoreComments" value="true"/>
+      <property name="ignoreUseStatements" value="true"/>
+    </properties>
+  </rule>
+</ruleset>

--- a/rector-ci.php
+++ b/rector-ci.php
@@ -7,7 +7,7 @@ use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitSelfCallRector;
 use Rector\Privatization\Rector\Class_\FinalizeTestCaseClassRector;
 
 return RectorConfig::configure()
-    ->withPhpSets(php83: true)
+    ->withPhpSets(php84: true)
     ->withAttributesSets(symfony: true, phpunit: true)
     ->withComposerBased(phpunit: true, symfony: true)
     ->withRules([

--- a/src/Command/CopyConnectionSchemaCommand.php
+++ b/src/Command/CopyConnectionSchemaCommand.php
@@ -60,7 +60,7 @@ final class CopyConnectionSchemaCommand extends Command
             return Command::INVALID;
         }
 
-        $confirmation = (new SymfonyStyle($input, $output))
+        $confirmation = new SymfonyStyle($input, $output)
             ->confirm(
                 sprintf('WARNING! Connection named "%s" schema and data will be PURGED. Do you want to continue?', $to),
                 !$input->isInteractive()

--- a/src/Command/LoadFixturesCommand.php
+++ b/src/Command/LoadFixturesCommand.php
@@ -43,7 +43,7 @@ abstract class LoadFixturesCommand extends Command
         $fixtureType = static::getFixtureType();
 
         if (!($append = (bool) filter_var($input->getOption(self::OPTION_APPEND), FILTER_VALIDATE_BOOLEAN))
-            && !(new SymfonyStyle($input, $output))->confirm(
+            && !new SymfonyStyle($input, $output)->confirm(
                 sprintf(
                     'Careful, Fixture type "%s" named "%s" will be purged. Do you want to continue?',
                     $fixtureType,

--- a/src/DependencyInjection/Compiler/CachePoolCompilerPass.php
+++ b/src/DependencyInjection/Compiler/CachePoolCompilerPass.php
@@ -27,7 +27,9 @@ final class CachePoolCompilerPass extends AbstractLoadFixturesCommandCompilerPas
             return;
         }
 
-        foreach ($this->getOrchestratorsIds($container, $container->findTaggedServiceIds(self::CACHE_POOL_TAG)) as $id) {
+        foreach (
+            $this->getOrchestratorsIds($container, $container->findTaggedServiceIds(self::CACHE_POOL_TAG)) as $id
+        ) {
             $this->buildContainerDefinitions($container, $id);
         }
     }

--- a/src/DependencyInjection/Compiler/HttpClientCompilerPass.php
+++ b/src/DependencyInjection/Compiler/HttpClientCompilerPass.php
@@ -60,7 +60,11 @@ final class HttpClientCompilerPass extends AbstractCompilerPass
                 ),
             ],
             // Executor Definition for HttpClient with provided id
-            executorDefinitionBuilder: static fn(ContainerBuilder $container, string $baseId, string $purgerId): array => [
+            executorDefinitionBuilder: static fn(
+                ContainerBuilder $container,
+                string $baseId,
+                string $purgerId,
+            ): array => [
                 sprintf('%s.%s.executor', self::SERVICE_PREFIX, $baseId),
                 new Definition(
                     HttpClientExecutor::class,

--- a/src/DependencyInjection/KununuTestingExtension.php
+++ b/src/DependencyInjection/KununuTestingExtension.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Kununu\TestingBundle\DependencyInjection;
 
+use Exception;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -28,10 +29,11 @@ final class KununuTestingExtension extends Extension implements ExtensionConfigu
 
     private array $config = [];
 
+    /** @throws Exception */
     public function load(array $configs, ContainerBuilder $container): void
     {
         $this->config = $this->processConfiguration(new Configuration(), $configs);
-        (new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config')))->load('services.yaml');
+        new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'))->load('services.yaml');
 
         foreach (self::CONNECTIONS as $section) {
             if (!empty($this->config[$section])) {

--- a/tests/App/Fixtures/Connection/ConnectionFixture1.php
+++ b/tests/App/Fixtures/Connection/ConnectionFixture1.php
@@ -14,8 +14,16 @@ final class ConnectionFixture1 implements ConnectionFixtureInterface, Initializa
 
     public function load(Connection $connection): void
     {
-        $connection->executeStatement('INSERT INTO `table_1` (`name`, `description`) VALUES (\'name\', \'description\');');
-        $connection->executeStatement('INSERT INTO `table_2` (`name`, `description`) VALUES (\'name\', \'description\');');
+        $connection->executeStatement(
+            <<<'SQL'
+INSERT INTO `table_1` (`name`, `description`) VALUES ('name', 'description');
+SQL
+        );
+        $connection->executeStatement(
+            <<<'SQL'
+INSERT INTO `table_2` (`name`, `description`) VALUES ('name', 'description');
+SQL
+        );
     }
 
     public function initializeFixture(mixed ...$args): void

--- a/tests/App/Fixtures/Connection/ConnectionFixture2.php
+++ b/tests/App/Fixtures/Connection/ConnectionFixture2.php
@@ -10,7 +10,15 @@ final readonly class ConnectionFixture2 implements ConnectionFixtureInterface
 {
     public function load(Connection $connection): void
     {
-        $connection->executeStatement('INSERT INTO `table_1` (`name`, `description`) VALUES (\'name\', \'description\');');
-        $connection->executeStatement('INSERT INTO `table_2` (`name`, `description`) VALUES (\'name\', \'description\');');
+        $connection->executeStatement(
+            <<<'SQL'
+INSERT INTO `table_1` (`name`, `description`) VALUES ('name', 'description');
+SQL
+        );
+        $connection->executeStatement(
+            <<<'SQL'
+INSERT INTO `table_2` (`name`, `description`) VALUES ('name', 'description');
+SQL
+        );
     }
 }

--- a/tests/App/Fixtures/Connection/ConnectionFixture3.php
+++ b/tests/App/Fixtures/Connection/ConnectionFixture3.php
@@ -10,7 +10,15 @@ final readonly class ConnectionFixture3 implements ConnectionFixtureInterface
 {
     public function load(Connection $connection): void
     {
-        $connection->executeStatement('INSERT INTO `table_1` (`name`, `description`) VALUES (\'name3\', \'description3\');');
-        $connection->executeStatement('INSERT INTO `table_2` (`name`, `description`) VALUES (\'name3\', \'description3\');');
+        $connection->executeStatement(
+            <<<'SQL'
+INSERT INTO `table_1` (`name`, `description`) VALUES ('name3', 'description3');
+SQL
+        );
+        $connection->executeStatement(
+            <<<'SQL'
+INSERT INTO `table_2` (`name`, `description`) VALUES ('name3', 'description3');
+SQL
+        );
     }
 }

--- a/tests/App/Fixtures/Connection/ConnectionFixture4.php
+++ b/tests/App/Fixtures/Connection/ConnectionFixture4.php
@@ -10,7 +10,15 @@ final readonly class ConnectionFixture4 implements ConnectionFixtureInterface
 {
     public function load(Connection $connection): void
     {
-        $connection->executeStatement('INSERT INTO `table_1` (`name`, `description`) VALUES (\'name4\', \'description4\');');
-        $connection->executeStatement('INSERT INTO `table_2` (`name`, `description`) VALUES (\'name4\', \'description4\');');
+        $connection->executeStatement(
+            <<<'SQL'
+INSERT INTO `table_1` (`name`, `description`) VALUES ('name4', 'description4');
+SQL
+        );
+        $connection->executeStatement(
+            <<<'SQL'
+INSERT INTO `table_2` (`name`, `description`) VALUES ('name4', 'description4');
+SQL
+        );
     }
 }

--- a/tests/App/Fixtures/Connection/ConnectionFixture5.php
+++ b/tests/App/Fixtures/Connection/ConnectionFixture5.php
@@ -10,6 +10,10 @@ final readonly class ConnectionFixture5 implements ConnectionFixtureInterface
 {
     public function load(Connection $connection): void
     {
-        $connection->executeStatement('INSERT INTO `table_3` (`name`, `description`) VALUES (\'my_name\', \'description5\');');
+        $connection->executeStatement(
+            <<<'SQL'
+INSERT INTO `table_3` (`name`, `description`) VALUES ('my_name', 'description5');
+SQL
+        );
     }
 }

--- a/tests/App/Fixtures/Connection/ConnectionFixture6.php
+++ b/tests/App/Fixtures/Connection/ConnectionFixture6.php
@@ -10,6 +10,10 @@ final readonly class ConnectionFixture6 implements ConnectionFixtureInterface
 {
     public function load(Connection $connection): void
     {
-        $connection->executeStatement('INSERT INTO `table_3` (`name`, `description`) VALUES (\'my_name\', \'description6\');');
+        $connection->executeStatement(
+            <<<'SQL'
+INSERT INTO `table_3` (`name`, `description`) VALUES ('my_name', 'description6');
+SQL
+        );
     }
 }

--- a/tests/App/Fixtures/DynamoDb/DynamoDbFixture1.php
+++ b/tests/App/Fixtures/DynamoDb/DynamoDbFixture1.php
@@ -26,7 +26,8 @@ final class DynamoDbFixture1 extends DynamoDbFixture
             ]),
         ];
 
-        $this->setTableName('my_table')
+        $this
+            ->setTableName('my_table')
             ->addRecords($records);
     }
 }

--- a/tests/App/Fixtures/DynamoDb/DynamoDbFixture2.php
+++ b/tests/App/Fixtures/DynamoDb/DynamoDbFixture2.php
@@ -16,7 +16,8 @@ final class DynamoDbFixture2 extends DynamoDbFixture
             Value::stringValue('attr_2', 'Other test 4'),
         ]);
 
-        $this->setTableName('other_table')
+        $this
+            ->setTableName('other_table')
             ->addRecord($record);
     }
 }

--- a/tests/App/config/bootstrap.php
+++ b/tests/App/config/bootstrap.php
@@ -6,4 +6,5 @@ require dirname(__DIR__) . '/../../vendor/autoload.php';
 $_SERVER += $_ENV;
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
 $_SERVER['APP_DEBUG'] ??= $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
-$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
+$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] =
+    (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';

--- a/tests/Unit/KununuTestingBundleTest.php
+++ b/tests/Unit/KununuTestingBundleTest.php
@@ -34,7 +34,7 @@ final class KununuTestingBundleTest extends KernelTestCase
                 }
             );
 
-        (new KununuTestingBundle())->build($container);
+        new KununuTestingBundle()->build($container);
 
         self::assertEquals(
             [

--- a/tests/Unit/Service/OrchestratorTest.php
+++ b/tests/Unit/Service/OrchestratorTest.php
@@ -69,6 +69,6 @@ final class OrchestratorTest extends TestCase
 
     private function generateMockClassName(string $prefix): string
     {
-        return sprintf('%s%s', $prefix, md5((new DateTime())->format('Y-m-d H:i:s.uP')));
+        return sprintf('%s%s', $prefix, md5(new DateTime()->format('Y-m-d H:i:s.uP')));
     }
 }

--- a/tests/Unit/Service/SchemaCopy/Factory/AdapterFactoryTest.php
+++ b/tests/Unit/Service/SchemaCopy/Factory/AdapterFactoryTest.php
@@ -26,7 +26,7 @@ final class AdapterFactoryTest extends TestCase
             $this->expectException(UnsupportedDatabasePlatformException::class);
         }
 
-        $adapter = (new AdapterFactory())->createAdapter($connection);
+        $adapter = new AdapterFactory()->createAdapter($connection);
 
         if (null !== $expectedType) {
             self::assertEquals($expectedType, $adapter->type());

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,4 +11,4 @@ use Symfony\Component\ErrorHandler\ErrorHandler;
 // https://github.com/symfony/symfony/issues/53812#issuecomment-1962740145
 set_exception_handler([new ErrorHandler(), 'handleException']);
 
-(new Dotenv())->bootEnv(dirname(__DIR__) . '/tests/App/.env');
+new Dotenv()->bootEnv(dirname(__DIR__) . '/tests/App/.env');


### PR DESCRIPTION
# Description

The objective of this PR is to make PHP 8.4 the minimum supported version.

## Details
- Make PHP 8.4 the minimum supported version
- Adjust continuous integration workflow
 - Only support PHP 8.4
 - Rename some steps
 - Add names to all stages
 - Add PHP_CodeSniffer step
- Adjust rector rules for 8.4
- Apply new rector rules on all code
- Add action in `composer.json` to run PHP_CodeSniffer