### PR TITLE
docs: add kun-init 4-file documentation structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS.md
+
+## What this is
+
+`kununu/testing-bundle` is a Symfony bundle (`type: symfony-bundle`) that makes
+testing easier. It integrates with [`kununu/data-fixtures`](https://github.com/kununu/data-fixtures)
+to load fixtures in tests and provides helpers such as `WebTestCase`, a
+`RequestBuilder`, and a database schema copier.
+
+It is a library, not a deployed service, and is intended for `dev`/`test`
+environments only — never production.
+
+## Domain
+
+Fixture loading and test utilities for Symfony applications. Supported fixture
+types: Doctrine DBAL connections, cache pools, DynamoDB, Elasticsearch,
+OpenSearch, and Symfony HTTP Client.
+
+## Code layout
+
+- `src/Command/` — console commands that load fixtures and copy schemas.
+- `src/DependencyInjection/` — bundle extension, `Configuration`, and compiler
+  passes wiring each fixture type.
+- `src/Service/` — the `Orchestrator` and the `SchemaCopy` adapters/factory.
+- `src/Test/` — consumer-facing test helpers (`FixturesAwareTestCase`,
+  `WebTestCase`, `RequestBuilder`, options).
+- `src/Resources/config/` — service definitions.
+- `src/KununuTestingBundle.php` — bundle entrypoint.
+- `tests/` — `Unit/` and `Integration/` suites plus a test app under `tests/App/`.
+- `docs/` — per-feature documentation.
+
+PSR-4: `Kununu\TestingBundle\` → `src/`, `Kununu\TestingBundle\Tests\` → `tests/`.
+
+## Quality gates
+
+Defined as `composer` scripts (see `scripts` in `composer.json`):
+
+- `composer cs` — PHP CS Fixer (kununu standards).
+- `composer sniffer` — PHP_CodeSniffer (`phpcs.xml.dist`).
+- `composer phpstan` — PHPStan (`phpstan.neon.dist`).
+- `composer rector` — Rector (`rector-ci.php`), dry-run.
+- `composer unit` / `composer integration` / `composer test` — PHPUnit suites.
+
+CI runs via the "Continuous Integration" GitHub Actions workflow; SonarCloud
+gates quality. Full workflow is in `CONTRIBUTING.md`.
+
+## Hard constraints
+
+- Stay compatible with the version ranges pinned in `composer.json` (`require`),
+  including Symfony `^6.4 || ^7.4` and `doctrine/dbal ^3.10 || ^4.4`.
+- PHP version is pinned in `composer.json` (`require.php`).
+- Integration tests need real backing services (MySQL, Elasticsearch, OpenSearch);
+  see `CONTRIBUTING.md`.
+- This bundle must not be enabled in production.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,69 @@
 # Contributing
 
-Contributions are more than **welcome**.
+Contributions are welcome via Pull Requests on
+[GitHub](https://github.com/kununu/testing-bundle).
 
-We accept contributions via Pull Requests on [GitHub](https://github.com/kununu/testing-bundle).
+## Requirements
+
+- PHP as pinned in `composer.json` (`require.php`).
+- [Composer](https://getcomposer.org/).
+- For integration tests: the `pdo_mysql` extension, a MySQL server, an
+  Elasticsearch cluster, and an OpenSearch cluster.
+
+## Getting started
+
+Install dependencies:
+
+```shell
+composer install
+```
+
+To prepare a local environment for the integration tests, copy `tests/App/.env`
+to `tests/App/.env.test` and `tests/App/.env.local`, adjust them for your local
+services, then run:
+
+```shell
+./tests/setupLocalTests.sh
+```
+
+This reinstalls dependencies and provisions the test databases via
+`tests/App/bin/setup_databases.sh`.
+
+## Quality gates
+
+The following `composer` scripts are available (see `scripts` in `composer.json`
+for the full list):
+
+| Script | Purpose |
+| --- | --- |
+| `composer cs` | Apply PHP CS Fixer with kununu standards |
+| `composer sniffer` / `composer sniffer-fix` | Run PHP_CodeSniffer (`phpcs.xml.dist`) |
+| `composer phpstan` | Run PHPStan (`phpstan.neon.dist`) |
+| `composer rector` / `composer rector-fix` | Run Rector (`rector-ci.php`) |
+| `composer unit` | Run the Unit test suite |
+| `composer integration` | Run the Integration test suite |
+| `composer test` | Run the Unit and Integration suites |
+
+Coverage variants (`*-coverage`) are also defined. Run the checks locally before
+opening a Pull Request; the same gates run in CI via the "Continuous Integration"
+workflow, and SonarCloud enforces the quality gate.
+
+## Coding standards
+
+kununu coding standards extend PSR-2. The
+[`kununu/code-tools`](https://github.com/kununu/code-tools) package is already a
+dev dependency and exposes the commands used to meet them (`composer cs`,
+`composer sniffer`).
 
 ## Pull Requests
 
-- **[kununu Coding Standards](https://github.com/kununu/kununu-scripts)** - The kununu coding standards are an extension of the [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md). Check out [kununu Coding Standards](https://github.com/kununu/kununu-scripts) for more details. In development mode the package [kununu-scripts](https://github.com/kununu/kununu-scripts) is already a dependency that expose commands that you can use to meet our standards.
+- **Add tests.** Changes are not accepted without tests.
+- **Document behaviour changes.** Keep `CHANGELOG.md`, `README.md`, and any
+  affected files under `docs/` up to date.
+- **Follow SemVer.** This project uses [Semantic Versioning](https://semver.org/);
+  weigh API changes carefully.
+- **Branch from `main`.** `main` is the stable branch; create a branch per change.
+- **One Pull Request per change.** Split unrelated work into separate PRs.
+- **Be respectful.** See the [Code of Conduct](CODE_OF_CONDUCT.md).
 
-- **Add tests!** - to ensure a high quality code base, your code patch can't be accepted if it does not have tests.
-
-- **Document any change in behaviour** - Make sure the `CHANGELOG.md`, `README.md` and any other relevant documentation are kept up-to-date.
-
-- **Consider our release cycle** - Since we're using semantic versioning ([SemVer v2.0.0](http://semver.org/)). Changes to the API must be done with great consideration, and prevented if at all possible.
-
-- **Create feature branches** - Master is the stable branch, create a new branch for each feature.
-
-- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
-
-- **Be respectful** - Be excellent to other contributors. See our [Code of Conduct](CODE_OF_CONDUCT.md).
-
-**Happy coding**!
+Happy coding!

--- a/README.md
+++ b/README.md
@@ -94,32 +94,16 @@ See more:
 
 To test your code, load fixtures and call your endpoints, see:
 
-- [FixtureAwareTextCase](docs/Test/fixtures-aware-test-case.md)
+- [FixturesAwareTestCase](docs/Test/fixtures-aware-test-case.md)
 - [WebTestCase](docs/Test/web-test-case.md)
 - [Request Builder](docs/Test/request-builder.md)
 
 ------------------------------
 
-## Testing the bundle
+## Contributing
 
-This repository takes advantages of GitHub actions to run tests when a commit is performed to a branch.
-
-If you want to run the integration tests on your local machine you will need:
-
-- *pdo_mysql* extension
-- MySQL server
-- Elasticsearch cluster
-- OpenSearch cluster
-
-In your local environment to get everything ready for you, run `./tests/setupLocalTests.sh` and follow the instructions.
-
-Then you can run the tests: `vendor/bin/phpunit`.
-
-------------------------------
-
-## Contribute
-
-If you are interested in contributing read our [contributing guidelines](CONTRIBUTING.md).
+Interested in contributing? See our [contributing guidelines](CONTRIBUTING.md)
+for local setup, quality gates, and how to run the tests.
 
 ------------------------------
 


### PR DESCRIPTION
# Description

The objective of this PR is to add the standard kun-init 4-file documentation structure to this repository, giving humans and coding agents a consistent entrypoint.

The four files have strict, non-overlapping ownership:

- **README.md** — what the bundle is, installation, and usage. Now links to the contributing guide instead of duplicating dev setup.
- **AGENTS.md** — short agent brief: purpose, domain, code layout, quality gates, and hard constraints.
- **CONTRIBUTING.md** — reconciled to own all dev workflow (local setup, quality gates, running tests, PR conventions).
- **CLAUDE.md** — points to `@AGENTS.md`.

## Issues

- KUNAI-8

## Details

- Created `AGENTS.md` (short-form) and `CLAUDE.md` (`@AGENTS.md`).
- Reconciled `CONTRIBUTING.md`: it now owns the full development workflow. Fixed stale references — the coding-standards package `kununu-scripts` is now `kununu/code-tools` (the actual dev dependency), and "Master is the stable branch" is now `main`. Migrated the local-setup / test instructions here from the README.
- Trimmed the duplicated "Testing the bundle" dev-setup section from `README.md`, renamed the section to `## Contributing`, and fixed a typo in the usage links (`FixtureAwareTextCase` → `FixturesAwareTestCase`). Badges left untouched.
- Documentation only; no source or config changes. Quality gates are referenced by name and point to `composer.json` scripts rather than being hardcoded.

### Noted, not changed (conservative docs-only scope)

- `docs/FixturesTypes/*.md` link to `kununu/data-fixtures` via `blob/master`. These are links into a separate third-party repository, so they were left as-is rather than retargeted.
